### PR TITLE
Adds secondary and footer menus

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -7,9 +7,9 @@ editable_theme_settings:
  - ucb_be_boulder
  - ucb_rave_alerts
  - ucb_gtm_account
-# - ucb_secondary_menu
-# - ucb_footer_menu
+ # - ucb_secondary_menu_default_links
+ - ucb_secondary_menu_position
+ - ucb_secondary_menu_button_display
+ # - ucb_footer_menu_default_links
  - ucb_social_share_position
  - ucb_breadcrumb_nav
- - ucb_date_format
-

--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -13,3 +13,4 @@ editable_theme_settings:
  # - ucb_footer_menu_default_links
  - ucb_social_share_position
  - ucb_breadcrumb_nav
+ - ucb_date_format

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -134,17 +134,35 @@ class SiteConfiguration {
 			'#description'    => t('Google Tag Manager account number e.g. GTM-123456.'),
 		];
 
-		$form['ucb_secondary_menu'] = [
+		$form['ucb_secondary_menu_default_links'] = [
 			'#type'           => 'checkbox',
 			'#title'          => t('Display the standard Boulder secondary menu in the header navigation region.'),
-			'#default_value'  => theme_get_setting('ucb_secondary_menu', $themeName),
+			'#default_value'  => theme_get_setting('ucb_secondary_menu_default_links', $themeName),
 			'#description'    => t('Check this box if you would like to display the default Boulder secondary menu links in the header.')
 		];
 
-		$form['ucb_footer_menu'] = [
+		$form['ucb_secondary_menu_position'] = [
+			'#type'           => 'select',
+			'#title'          => t('Position of the secondary menu'),
+			'#default_value'  => theme_get_setting('ucb_secondary_menu_position', $themeName),
+			'#options'        => [
+				'inline' => t('Inline with the main navigation'),
+				'above'  => t('Above the main navigation')
+			],
+			'#description'    => t('The secondary menu of this site can be populated with secondary or action links and displayed inline with or above the main navigation.')
+		];
+
+		$form['ucb_secondary_menu_button_display'] = [
 			'#type'           => 'checkbox',
-			'#title'          => t('Display the standard Boulder menus in the header footer region.'),
-			'#default_value'  => theme_get_setting('ucb_footer_menu', $themeName),
+			'#title'          => t('Display links in the secondary menu as buttions'),
+			'#default_value'  => theme_get_setting('ucb_secondary_menu', $themeName),
+			'#description'    => t('Check this box to display the links in the secondary menu of this site as buttons instead of links.')
+		];
+
+		$form['ucb_footer_menu_default_links'] = [
+			'#type'           => 'checkbox',
+			'#title'          => t('Display the standard Boulder menus in the footer region.'),
+			'#default_value'  => theme_get_setting('ucb_footer_menu_default_links', $themeName),
 			'#description'    => t('Check this box if you would like to display the default Boulder footer menu links in the footer.')
 		];
 		// Choose where social share buttons are positioned on each page
@@ -160,22 +178,6 @@ class SiteConfiguration {
 				t('Below Title')
 			],
 			'#description'    => t('Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages.')
-		];
-		// Choose date/time format sitewide
-		$form['ucb_date_format'] = [
-			'#type'           => 'select',
-			'#title'          => t('Display settings for Date formats on Articles'),
-			'#default_value'  => theme_get_setting('ucb_date_format', $themeName),
-			'#options'        => [
-				t('Short Date'),
-				t('Medium Date'),
-				t('Long Date'),
-				t('Short Date with Time'),
-				t('Medium Date with Time'),
-				t('Long Date with Time'),
-				t('None - Hide')
-			],
-			'#description'    => t('Select the preferred Global Date/Time format for dates on your site.')
 		];
 	}
 }

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -155,7 +155,7 @@ class SiteConfiguration {
 		$form['ucb_secondary_menu_button_display'] = [
 			'#type'           => 'checkbox',
 			'#title'          => t('Display links in the secondary menu as buttions'),
-			'#default_value'  => theme_get_setting('ucb_secondary_menu', $themeName),
+			'#default_value'  => theme_get_setting('ucb_secondary_menu_button_display', $themeName),
 			'#description'    => t('Check this box to display the links in the secondary menu of this site as buttons instead of links.')
 		];
 
@@ -178,6 +178,22 @@ class SiteConfiguration {
 				t('Below Title')
 			],
 			'#description'    => t('Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages.')
+		];
+		// Choose date/time format sitewide
+		$form['ucb_date_format'] = [
+			'#type'           => 'select',
+			'#title'          => t('Display settings for Date formats on Articles'),
+			'#default_value'  => theme_get_setting('ucb_date_format', $themeName),
+			'#options'        => [
+				t('Short Date'),
+				t('Medium Date'),
+				t('Long Date'),
+				t('Short Date with Time'),
+				t('Medium Date with Time'),
+				t('Long Date with Time'),
+				t('None - Hide')
+			],
+			'#description'    => t('Select the preferred Global Date/Time format for dates on your site.')
 		];
 	}
 }


### PR DESCRIPTION
This update adds secondary and footer menus in the header and footer of the site. Like with the main navigation, links can be added when creating or editing a page. The secondary menu can be displayed either to the right of or above the main navigation, with the option to display action links as buttons.

CuBoulder/tiamat-theme#163

Sister PRs in:
- [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/22)
- [tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities/pull/29)
- [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/187)