### PR TITLE
Admin toolbar Helpscout Beacon integration

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -37,3 +37,5 @@ external_services:
     availability:
       content: true
       sitewide: true
+
+admin_helpscout_beacon_id: '1bb01225-0287-4443-a7e5-be8f375a7766'

--- a/css/admin-helpscout-beacon.css
+++ b/css/admin-helpscout-beacon.css
@@ -1,0 +1,1 @@
+#hs-beacon iframe {background:rgba(0,0,0,.75) !important; }

--- a/js/admin-helpscout-beacon.js
+++ b/js/admin-helpscout-beacon.js
@@ -3,11 +3,11 @@
 		attach: function (context, drupalSettings) {
 			const helpElement = document.querySelector('.menu-item__help-main a');
 			if(!helpElement) return;
-			const settings = drupalSettings['ucb_site_configuration']['admin_helpscout_beacon'];
+			const settings = drupalSettings['admin_helpscout_beacon'];
 			!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
-			window.Beacon('init', '1bb01225-0287-4443-a7e5-be8f375a7766');
-			window.Beacon('prefill', settings['prefill']);
-			window.Beacon('config', {
+			Beacon('init', settings['id']);
+			Beacon('prefill', settings['prefill']);
+			Beacon('config', {
 				'display': {
 					'style': 'manual',
 					'iconImage': 'message'
@@ -15,7 +15,7 @@
 			});
 			helpElement.onclick = function(event) {
 				event.preventDefault();
-				window.Beacon('open');
+				Beacon('open');
 			};
 		}
 	};

--- a/js/admin-helpscout-beacon.js
+++ b/js/admin-helpscout-beacon.js
@@ -1,0 +1,22 @@
+(function(Drupal) {
+	Drupal.behaviors.loadAdminHelpscountBeacon = {
+		attach: function (context, drupalSettings) {
+			const helpElement = document.querySelector('.menu-item__help-main a');
+			if(!helpElement) return;
+			const settings = drupalSettings['ucb_site_configuration']['admin_helpscout_beacon'];
+			!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});
+			window.Beacon('init', '1bb01225-0287-4443-a7e5-be8f375a7766');
+			window.Beacon('prefill', settings['prefill']);
+			window.Beacon('config', {
+				'display': {
+					'style': 'manual',
+					'iconImage': 'message'
+				}
+			});
+			helpElement.onclick = function(event) {
+				event.preventDefault();
+				window.Beacon('open');
+			};
+		}
+	};
+})(Drupal);

--- a/js/admin-helpscout-beacon.js
+++ b/js/admin-helpscout-beacon.js
@@ -1,5 +1,5 @@
 (function(Drupal) {
-	Drupal.behaviors.loadAdminHelpscountBeacon = {
+	Drupal.behaviors.adminHelpscoutBeacon = {
 		attach: function (context, drupalSettings) {
 			const helpElement = document.querySelector('.menu-item__help-main a');
 			if(!helpElement) return;

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\ucb_site_configuration\Controller\HelpController.
+ */
+
+namespace Drupal\ucb_site_configuration\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+
+class HelpController extends ControllerBase {
+	/**
+	 * @return \Drupal\Core\Routing\TrustedRedirectResponse
+	 *   A redirect to the CU Boulder web support site.
+	 */
+	public function helpRedirect() {
+		return new TrustedRedirectResponse('https://websupport.colorado.edu/');
+	}
+}

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -6,5 +6,6 @@ version: '2.0'
 package: CU Boulder
 dependencies:
   - block
+  - help # this module has routes that override those in help
   - node
   - system

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Adds id for the admin Helpscout Beacon.
+ */
+function ucb_site_configuration_update_9501() {
+	$config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
+	$config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
+}

--- a/ucb_site_configuration.libraries.yml
+++ b/ucb_site_configuration.libraries.yml
@@ -1,0 +1,9 @@
+admin_helpscout_beacon:
+  version: 1.0
+  js:
+    js/admin-helpscout-beacon.js: {}
+  css:
+    theme:
+      css/admin-helpscout-beacon.css: {}
+  dependencies:
+    - core/drupalSettings

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -4,6 +4,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
+ * Adds the Helpscout Beacon widget if the user has permission to see the admin toolbar.
  * Implements hook_page_attachments_alter().
  */
 function ucb_site_configuration_page_attachments_alter(array &$page) {
@@ -13,10 +14,19 @@ function ucb_site_configuration_page_attachments_alter(array &$page) {
 		$service = \Drupal::service('ucb_site_configuration');
 		$config = $service->getConfiguration();
 		$roles = join(', ', $user->getRoles());
+  		$site_name = \Drupal::config('system.site')->get('name');
+		$site_name = str_replace(' ', '-', $site_name);
+		$site_name = preg_replace('/[^A-Za-z0-9\-]/', '', $site_name);
 		$page['#attached']['library'][] = 'ucb_site_configuration/admin_helpscout_beacon';
-		$page['#attached']['drupalSettings']['ucb_site_configuration']['admin_helpscout_beacon'] = [
+		$page['#attached']['drupalSettings']['admin_helpscout_beacon'] = [
+			'id' => $config->get('admin_helpscout_beacon_id'),
 			'prefill' => [
-				'roles' => $roles
+				'name' => $user->getDisplayName(),
+				'email' => $user->getEmail(),
+				'user_email' => $user->getEmail(),
+				'roles' => $roles,
+				'site_name' => $site_name,
+				'site_url' => (stripos($_SERVER['SERVER_PROTOCOL'], 'https') === 0 ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
 			]
 		];
 	}
@@ -24,6 +34,7 @@ function ucb_site_configuration_page_attachments_alter(array &$page) {
 
 /**
  * Enables external service includes to be referenced from the page template.
+ * Implements hook_preprocess_HOOK().
  */
 function ucb_site_configuration_preprocess_page(array &$variables) {
 	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -4,6 +4,25 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
+ * Implements hook_page_attachments_alter().
+ */
+function ucb_site_configuration_page_attachments_alter(array &$page) {
+	$user = \Drupal::currentUser();
+	if ($user->hasPermission('access toolbar')) {
+		/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
+		$service = \Drupal::service('ucb_site_configuration');
+		$config = $service->getConfiguration();
+		$roles = join(', ', $user->getRoles());
+		$page['#attached']['library'][] = 'ucb_site_configuration/admin_helpscout_beacon';
+		$page['#attached']['drupalSettings']['ucb_site_configuration']['admin_helpscout_beacon'] = [
+			'prefill' => [
+				'roles' => $roles
+			]
+		];
+	}
+}
+
+/**
  * Enables external service includes to be referenced from the page template.
  */
 function ucb_site_configuration_preprocess_page(array &$variables) {

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -60,3 +60,19 @@ entity.ucb_external_service_include.delete_form:
     _title: Delete a third-party service
   requirements:
     _permission: administer ucb external services
+
+help.main:
+  path: /admin/help
+  defaults:
+    _controller: 'Drupal\ucb_site_configuration\Controller\HelpController::helpRedirect'
+    _title: 'Help'
+  requirements:
+    _permission: access administration pages
+
+help.page:
+  path: '/admin/help/{name}'
+  defaults:
+    _controller: 'Drupal\ucb_site_configuration\Controller\HelpController::helpRedirect'
+    _title: 'Help'
+  requirements:
+    _permission: access administration pages


### PR DESCRIPTION
This update integrates Helpscout Beacon into the admin toolbar "Help" item for both normal and administration pages, providing quick access to help topics or to ask a question. It also redirects the default Drupal help pages to more relevant help documentation at https://websupport.colorado.edu/.

Resolves CuBoulder/tiamat-theme#170