### PR TITLE
Adds site type, site affiliation

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -1,108 +1,166 @@
 # Configuration for this module will go here
 
 site_type_options:
-  college: 'College'
-  school: 'School'
-  academic_department: 'Academic Department'
-  academic_program: 'Academic Program'
-  certificate_program: 'Certificate Program'
-  outreach_program: 'Outreach Program'
-  residential_academic_program: 'Residential Academic Program'
-  academic_support: 'Academic Support'
-  center: 'Center'
-  institute: 'Institute'
-  service_department: 'Service Department'
-  resource_department: 'Resource Department'
-  support_department: 'Support Department'
-  performance: 'Performance'
-  event: 'Event'
-  museum: 'Museum'
-  research_program: 'Research Program'
-  lab: 'Lab'
-  faculty: 'Faculty'
-  student_group: 'Student Group'
-  sport_club: 'Sport Club'
-  publication: 'Publication'
+  college: 
+    label: 'College'
+  school:
+    label: 'School'
+  academic_department:
+    label: 'Academic Department'
+  academic_program:
+    label: 'Academic Program'
+  certificate_program:
+    label: 'Certificate Program'
+  outreach_program:
+    label: 'Outreach Program'
+  residential_academic_program:
+    label: 'Residential Academic Program'
+  academic_support:
+    label: 'Academic Support'
+  center:
+    label: 'Center'
+  institute:
+    label: 'Institute'
+  service_department:
+    label: 'Service Department'
+  resource_department:
+    label: 'Resource Department'
+  support_department:
+    label: 'Support Department'
+  performance:
+    label: 'Performance'
+  event:
+    label: 'Event'
+  museum:
+    label: 'Museum'
+  research_program:
+    label: 'Research Program'
+  lab:
+    label: 'Lab'
+  faculty:
+    label: 'Faculty'
+  student_group:
+    label: 'Student Group'
+    affiliation: student_group
+  sport_club:
+    label: 'Sport Club'
+    affiliation: sport_club
+  publication:
+    label: 'Publication'
 
 site_affiliation_options:
   arts_sciences:
     url: 'https://www.colorado.edu/artsandsciences'
     label: 'College of Arts and Sciences'
+    type_restricted: false
   business:
     url: 'https://www.colorado.edu/business'
     label: 'Leeds School of Business'
+    type_restricted: false
   education:
     url: 'https://www.colorado.edu/education'
     label: 'School of Education'
+    type_restricted: false
   engineering:
     url: 'https://www.colorado.edu/engineering'
     label: 'College of Engineering and Applied Science'
+    type_restricted: false
   cmci:
     url: 'https://www.colorado.edu/cmci'
     label: 'College of Media, Communication and Information'
+    type_restricted: false
   music:
     url: 'https://www.colorado.edu/music'
     label: 'College of Music'
+    type_restricted: false
   law:
     url: 'https://www.colorado.edu/law'
     label: 'School of Law'
+    type_restricted: false
   graduate_school:
     url: 'https://www.colorado.edu/graduateschool'
     label: 'Graduate School'
+    type_restricted: false
   continuing_education:
     url: 'https://ce.colorado.edu/'
     label: 'Division of Continuing Education'
+    type_restricted: false
   university_libraries:
     url: 'https://www.colorado.edu/libraries'
     label: 'University Libraries'
+    type_restricted: false
   biofrontiers_institute:
     url: 'https://www.colorado.edu/biofrontiers'
     label: 'Biofrontiers Institute'
+    type_restricted: false
   odece:
     url: 'https://www.colorado.edu/odece'
     label: 'Office of Diversity, Equity and Community Engagement'
+    type_restricted: false
   faculty_affairs:
     url: 'https://www.colorado.edu/facultyaffairs'
     label: 'Office of Faculty Affairs'
+    type_restricted: false
   ombuds:
     url: 'https://www.colorado.edu/ombuds'
     label: 'Ombuds Office'
+    type_restricted: false
   research_innovation_office:
     url: 'https://www.colorado.edu/researchinnovation'
     label: 'Research and Innovation Office'
+    type_restricted: false
   strategic_initiatives:
     url: 'https://www.colorado.edu/osi'
     label: 'Office of Strategic Initiatives'
+    type_restricted: false
   student_affairs:
     url: 'https://www.colorado.edu/studentaffairs'
     label: 'Division of Student Affairs'
+    type_restricted: false
   undergraduate_education:
     url: ''
     label: 'Office of Undergraduate Education'
+    type_restricted: false
   enrollment_management:
     url: ''
     label: 'Part of Enrollment Management'
+    type_restricted: false
   finance_business_strategy:
     url: 'https://www.colorado.edu/fbs'
     label: 'Part of Finance and Business Strategy'
+    type_restricted: false
   human_resources:
     url: 'https://www.colorado.edu/hr'
     label: 'Department of Human Resources'
+    type_restricted: false
   information_technology:
     url: 'https://oit.colorado.edu/'
     label: 'Office of Information Technology'
+    type_restricted: false
   infrastructure_sustainability:
     url: 'https://www.colorado.edu/infrastructure-sustainability'
     label: 'Part of Infrastructure and Sustainability'
+    type_restricted: false
   institutional_equity_compliance:
     url: 'https://www.colorado.edu/oiec'
     label: 'Office of Institutional Equity'
+    type_restricted: false
   integrity_safety_compliance:
     url: ''
     label: 'Office of Integrity, Safety and Compliance'
+    type_restricted: false
   strategic_relations_comm:
     url: 'https://www.colorado.edu/strategicrelations'
     label: 'Part of Strategic Relations and Communications'
+    type_restricted: false
+  student_group:
+    url: 'https://www.colorado.edu/involvement'
+    label: 'A CU Boulder Student Group'
+    type_restricted: true
+  sport_club:
+    url: 'https://www.colorado.edu/recreation'
+    label: 'A CU Boulder Sport Club'
+    type_restricted: true
 
 editable_theme_settings: 
  - ucb_campus_header_color

--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -1,5 +1,109 @@
 # Configuration for this module will go here
 
+site_type_options:
+  college: 'College'
+  school: 'School'
+  academic_department: 'Academic Department'
+  academic_program: 'Academic Program'
+  certificate_program: 'Certificate Program'
+  outreach_program: 'Outreach Program'
+  residential_academic_program: 'Residential Academic Program'
+  academic_support: 'Academic Support'
+  center: 'Center'
+  institute: 'Institute'
+  service_department: 'Service Department'
+  resource_department: 'Resource Department'
+  support_department: 'Support Department'
+  performance: 'Performance'
+  event: 'Event'
+  museum: 'Museum'
+  research_program: 'Research Program'
+  lab: 'Lab'
+  faculty: 'Faculty'
+  student_group: 'Student Group'
+  sport_club: 'Sport Club'
+  publication: 'Publication'
+
+site_affiliation_options:
+  arts_sciences:
+    url: 'https://www.colorado.edu/artsandsciences'
+    label: 'College of Arts and Sciences'
+  business:
+    url: 'https://www.colorado.edu/business'
+    label: 'Leeds School of Business'
+  education:
+    url: 'https://www.colorado.edu/education'
+    label: 'School of Education'
+  engineering:
+    url: 'https://www.colorado.edu/engineering'
+    label: 'College of Engineering and Applied Science'
+  cmci:
+    url: 'https://www.colorado.edu/cmci'
+    label: 'College of Media, Communication and Information'
+  music:
+    url: 'https://www.colorado.edu/music'
+    label: 'College of Music'
+  law:
+    url: 'https://www.colorado.edu/law'
+    label: 'School of Law'
+  graduate_school:
+    url: 'https://www.colorado.edu/graduateschool'
+    label: 'Graduate School'
+  continuing_education:
+    url: 'https://ce.colorado.edu/'
+    label: 'Division of Continuing Education'
+  university_libraries:
+    url: 'https://www.colorado.edu/libraries'
+    label: 'University Libraries'
+  biofrontiers_institute:
+    url: 'https://www.colorado.edu/biofrontiers'
+    label: 'Biofrontiers Institute'
+  odece:
+    url: 'https://www.colorado.edu/odece'
+    label: 'Office of Diversity, Equity and Community Engagement'
+  faculty_affairs:
+    url: 'https://www.colorado.edu/facultyaffairs'
+    label: 'Office of Faculty Affairs'
+  ombuds:
+    url: 'https://www.colorado.edu/ombuds'
+    label: 'Ombuds Office'
+  research_innovation_office:
+    url: 'https://www.colorado.edu/researchinnovation'
+    label: 'Research and Innovation Office'
+  strategic_initiatives:
+    url: 'https://www.colorado.edu/osi'
+    label: 'Office of Strategic Initiatives'
+  student_affairs:
+    url: 'https://www.colorado.edu/studentaffairs'
+    label: 'Division of Student Affairs'
+  undergraduate_education:
+    url: ''
+    label: 'Office of Undergraduate Education'
+  enrollment_management:
+    url: ''
+    label: 'Part of Enrollment Management'
+  finance_business_strategy:
+    url: 'https://www.colorado.edu/fbs'
+    label: 'Part of Finance and Business Strategy'
+  human_resources:
+    url: 'https://www.colorado.edu/hr'
+    label: 'Department of Human Resources'
+  information_technology:
+    url: 'https://oit.colorado.edu/'
+    label: 'Office of Information Technology'
+  infrastructure_sustainability:
+    url: 'https://www.colorado.edu/infrastructure-sustainability'
+    label: 'Part of Infrastructure and Sustainability'
+  institutional_equity_compliance:
+    url: 'https://www.colorado.edu/oiec'
+    label: 'Office of Institutional Equity'
+  integrity_safety_compliance:
+    url: ''
+    label: 'Office of Integrity, Safety and Compliance'
+  strategic_relations_comm:
+    url: 'https://www.colorado.edu/strategicrelations'
+    label: 'Part of Strategic Relations and Communications'
+
 editable_theme_settings: 
  - ucb_campus_header_color
  - ucb_header_color

--- a/config/install/ucb_site_configuration.settings.yml
+++ b/config/install/ucb_site_configuration.settings.yml
@@ -1,1 +1,6 @@
 # Editable site settings (non-theme) will go here
+
+site_type: ''
+site_affiliation: ''
+site_affiliation_label: ''
+site_affiliation_url: ''

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\ucb_site_configuration\Form\SettingsForm.
+ * Contains \Drupal\ucb_site_configuration\Form\AppearanceForm.
  */
 
 namespace Drupal\ucb_site_configuration\Form;
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class SettingsForm extends ConfigFormBase {
+class AppearanceForm extends ConfigFormBase {
 
 	/**
 	 * The user site configuration service defined in this module.
@@ -23,7 +23,7 @@ class SettingsForm extends ConfigFormBase {
 	protected $service;
 
 	/**
-	 * Constructs a SettingsForm object.
+	 * Constructs a AppearanceForm object.
 	 *
 	 * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
 	 *   The config factory.
@@ -61,7 +61,7 @@ class SettingsForm extends ConfigFormBase {
 	 * {@inheritdoc}
 	 */
 	public function getFormId() {
-		return 'ucb_site_configuration_settings_form';
+		return 'ucb_site_configuration_appearance_form';
 	}
 
 	/**

--- a/src/Form/GeneralForm.php
+++ b/src/Form/GeneralForm.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\ucb_site_configuration\Form\GeneralForm.
+ */
+
+namespace Drupal\ucb_site_configuration\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ucb_site_configuration\SiteConfiguration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class GeneralForm extends ConfigFormBase {
+
+	/**
+	 * The user site configuration service defined in this module.
+	 *
+	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
+	 */
+	protected $service;
+
+	/**
+	 * Constructs a GeneralForm object.
+	 *
+	 * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+	 *   The config factory.
+	 * @param \Drupal\ucb_site_configuration\UserInviteHelperService $helper
+	 *   The user invite helper service defined in this module.
+	 */
+	public function __construct(ConfigFactoryInterface $config_factory, SiteConfiguration $service) {
+		parent::__construct($config_factory);
+		$this->service = $service;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+	 *   The container that allows getting any needed services.
+	 *
+	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
+	 */
+	public static function create(ContainerInterface $container) {
+		return new static(
+			$container->get('config.factory'),
+			$container->get('ucb_site_configuration')
+		);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getEditableConfigNames() {
+		return ['system.site', 'ucb_site_configuration.settings'];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFormId() {
+		return 'ucb_site_configuration_general_form';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function buildForm(array $form, FormStateInterface $form_state) {
+		$configuration = $this->service->getConfiguration();
+		$settings = $this->service->getSettings();
+		$form['site_name'] = [
+			'#type' => 'textfield',
+			'#title' => $this->t('Site name'),
+			'#default_value' => $this->config('system.site')->get('name'),
+			'#required' => TRUE
+		];
+		$form['site_type'] = [
+			'#type' => 'select',
+			'#title' => $this->t('Site type'),
+			'#default_value' => $settings->get('site_type'),
+			'#options' => array_merge(['' => $this->t('- None -')], $configuration->get('site_type_options')),
+			'#required' => FALSE
+		];
+		$form['site_affiliation'] = [
+			'#type' => 'select',
+			'#title' => $this->t('Site affiliation'),
+			'#default_value' => $settings->get('site_affiliation'),
+			'#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) { return $value['label']; }, $configuration->get('site_affiliation_options')), ['custom' =>  $this->t('Custom')]),
+			'#required' => FALSE
+		];
+		$form['site_affiliation_custom'] = [
+			'#type' => 'fieldset',
+			'#description' => $this->t('Define a title and optional URL for the custom site affiliation.'),
+			'#states' => [
+				'visible' => [':input[name="site_affiliation"]' => ['value' => 'custom']]
+			],
+			'site_affiliation_label' => [
+				'#type' => 'textfield',
+				'#title' => $this->t('Title'),
+				'#default_value' => $settings->get('site_affiliation_label'),
+				'#required' => FALSE,
+				'#maxlength' => 255,
+				'#states' => [
+					'required' => [':input[name="site_affiliation"]' => ['value' => 'custom']]
+				]
+			],
+			'site_affiliation_url' => [
+				'#type' => 'textfield',
+				'#title' => $this->t('URL'),
+				'#default_value' => $settings->get('site_affiliation_url'),
+				'#required' => FALSE,
+				'#maxlength' => 255
+			]
+		];
+		return parent::buildForm($form, $form_state);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function submitForm(array &$form, FormStateInterface $form_state) {
+		$this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
+		$this->config('ucb_site_configuration.settings')
+			->set('site_type', $form_state->getValue('site_type'))
+			->set('site_affiliation', $form_state->getValue('site_affiliation'))
+			->set('site_affiliation_label', $form_state->getValue('site_affiliation_label'))
+			->set('site_affiliation_url', $form_state->getValue('site_affiliation_url'))
+			->save();
+		parent::submitForm($form, $form_state);
+	}
+}

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -286,15 +286,17 @@ class SiteConfiguration {
 	public function attachSiteInformation(array &$variables) {
 		$configuration = $this->getConfiguration();
 		$settings = $this->getSettings();
+		$siteTypeOptions = $configuration->get('site_type_options');
+		$siteAffiliationOptions = $configuration->get('site_affiliation_options');
 		$variables['site_name'] = $this->configFactory->get('system.site')->get('name');
 		$siteTypeId = $settings->get('site_type');
 		$variables['site_type'] = [
 			'id' => $siteTypeId,
-			'label' => $siteTypeId && isset($configuration->get('site_type_options')[$siteTypeId]) ? $configuration->get('site_type_options')[$siteTypeId]['label'] : $siteTypeId
+			'label' => $siteTypeId && isset($siteTypeOptions[$siteTypeId]) ? $siteTypeOptions[$siteTypeId]['label'] : $siteTypeId
 		];
 		$siteAffiliationId = $settings->get('site_affiliation');
-		$siteAffiliationAttribs = $siteAffiliationId ? $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label') ?? $siteAffiliationId, 'url' => $settings->get('site_affiliation_url')] : $configuration->get('site_affiliation_options')[$siteAffiliationId] ?? null : null;
-		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs ?? ['label' => $siteAffiliationId, 'url' => '']);	
+		$siteAffiliationAttribs = $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label'), 'url' => $settings->get('site_affiliation_url')] : ($siteAffiliationId && isset($siteAffiliationOptions[$siteAffiliationId]) ? $siteAffiliationOptions[$siteAffiliationId] : ['label' => $siteAffiliationId ?? '', 'url' => '']);
+		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs);	
 	}
 
 	/**

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -278,7 +278,27 @@ class SiteConfiguration {
 	}
 
 	/**
-	 * This helper funtion attaches external service includes if called from hook_preprocess in the .module file.
+	 * This helper function attaches site information if called from hook_preprocess in the .module file.
+	 * 
+	 * @param array &$variables
+	 *   The array to add the site information to.
+	 */
+	public function attachSiteInformation(array &$variables) {
+		$configuration = $this->getConfiguration();
+		$settings = $this->getSettings();
+		$variables['site_name'] = $this->configFactory->get('system.site')->get('name');
+		$siteTypeId = $settings->get('site_type');
+		$variables['site_type'] = [
+			'id' => $siteTypeId,
+			'label' => $siteTypeId ? $configuration->get('site_type_options')[$siteTypeId] ?? '' : ''
+		];
+		$siteAffiliationId = $settings->get('site_affiliation');
+		$siteAffiliationAttribs = $siteAffiliationId ? $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label'), 'url' => $settings->get('site_affiliation_url')] : $configuration->get('site_affiliation_options')[$siteAffiliationId] ?? null : null;
+		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs ?? ['label' => '', 'url' => '']);	
+	}
+
+	/**
+	 * This helper function attaches external service includes if called from hook_preprocess in the .module file.
 	 * Variables can be referenced from the template using `service_servicename_includes`.
 	 * 
 	 * @param array &$variables

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -290,11 +290,11 @@ class SiteConfiguration {
 		$siteTypeId = $settings->get('site_type');
 		$variables['site_type'] = [
 			'id' => $siteTypeId,
-			'label' => $siteTypeId ? $configuration->get('site_type_options')[$siteTypeId] ?? '' : ''
+			'label' => $siteTypeId && isset($configuration->get('site_type_options')[$siteTypeId]) ? $configuration->get('site_type_options')[$siteTypeId]['label'] : $siteTypeId
 		];
 		$siteAffiliationId = $settings->get('site_affiliation');
-		$siteAffiliationAttribs = $siteAffiliationId ? $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label'), 'url' => $settings->get('site_affiliation_url')] : $configuration->get('site_affiliation_options')[$siteAffiliationId] ?? null : null;
-		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs ?? ['label' => '', 'url' => '']);	
+		$siteAffiliationAttribs = $siteAffiliationId ? $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label') ?? $siteAffiliationId, 'url' => $settings->get('site_affiliation_url')] : $configuration->get('site_affiliation_options')[$siteAffiliationId] ?? null : null;
+		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs ?? ['label' => $siteAffiliationId, 'url' => '']);	
 	}
 
 	/**

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.0'
+version: '2.1'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -1,4 +1,5 @@
 <?php
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Adds id for the admin Helpscout Beacon.
@@ -6,4 +7,17 @@
 function ucb_site_configuration_update_9501() {
 	$config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
 	$config->set('admin_helpscout_beacon_id', '1bb01225-0287-4443-a7e5-be8f375a7766')->save();
+}
+
+/**
+ * Adds configuration and settings for the site type and affiliation.
+ */
+function ucb_site_configuration_update_9502() {
+	$config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
+	$settings = \Drupal::configFactory()->getEditable('ucb_site_configuration.settings');
+	$yaml = Yaml::parse(file_get_contents(drupal_get_path('module', 'ucb_site_configuration') . '/config/install/ucb_site_configuration.configuration.yml'));
+	if (!is_array($yaml))
+		throw new \RuntimeException('Oh no! Failed to get or parse site type and affiliation configuration YAML.');
+	$config->set('site_type_options', $yaml['site_type_options'])->set('site_affiliation_options', $yaml['site_affiliation_options'])->save();
+	$settings->set('site_type', '')->set('site_affiliation', '')->set('site_affiliation_label', '')->set('site_affiliation_url', '')->save();
 }

--- a/ucb_site_configuration.links.menu.yml
+++ b/ucb_site_configuration.links.menu.yml
@@ -5,23 +5,27 @@ ucb_site_configuration:
   parent: system.admin_config
   weight: 0
 
+ucb_site_configuration.general_form:
+  title: General
+  description: 'Modify general settings and information such as the site name, type, and affiliation.'
+  route_name: ucb_site_configuration.general_form
+  parent: ucb_site_configuration
+  weight: 0
 ucb_site_configuration.appearance_form:
   title: Appearance
   description: 'Change the appearance, layout, and formatting of the site theme.'
   route_name: ucb_site_configuration.appearance_form
   parent: ucb_site_configuration
-  weight: 0
-
+  weight: 1
 ucb_site_configuration.contact_info_form:
   title: Contact info
   description: 'Modify the contact info for the site as it appears in the site footer.'
   route_name: ucb_site_configuration.contact_info_form
   parent: ucb_site_configuration
-  weight: 1
-
+  weight: 2
 ucb_site_configuration.external_services:
   title: Third-party services
   description: 'Configure third-party services to be used on the site.'
   route_name: entity.ucb_external_service_include.collection
   parent: ucb_site_configuration
-  weight: 2
+  weight: 3

--- a/ucb_site_configuration.links.task.yml
+++ b/ucb_site_configuration.links.task.yml
@@ -1,3 +1,8 @@
+ucb_site_configuration.general_form:
+  route_name: ucb_site_configuration.general_form
+  title: 'General'
+  base_route: ucb_site_configuration
+  weight: 0
 ucb_site_configuration.appearance_form:
   route_name: ucb_site_configuration.appearance_form
   title: 'Appearance'

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -39,9 +39,12 @@ function ucb_site_configuration_page_attachments_alter(array &$page) {
 function ucb_site_configuration_preprocess_page(array &$variables) {
 	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
 	$service = \Drupal::service('ucb_site_configuration');
+	$service->attachSiteInformation($variables);
 	if (($node = \Drupal::routeMatch()->getParameter('node')) && $node instanceof NodeInterface) {
 		$service->attachExternalServiceIncludes($variables, $node);
 	} else $service->attachExternalServiceIncludes($variables);
+	$variables['#cache']['tags'][] = 'config:ucb_site_configuration.configuration';
+	$variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
 }
 
 /**

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -26,7 +26,7 @@ function ucb_site_configuration_page_attachments_alter(array &$page) {
 				'user_email' => $user->getEmail(),
 				'roles' => $roles,
 				'site_name' => $site_name,
-				'site_url' => ($_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
+				'site_url' => (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . \Drupal::request()->getRequestUri()
 			]
 		];
 	}

--- a/ucb_site_configuration.permissions.yml
+++ b/ucb_site_configuration.permissions.yml
@@ -1,3 +1,7 @@
+edit ucb site general:
+  title: Edit the site general settings
+  description: 'Enables editing of the CU Boulder general site settings and information such as the site name, type, and affiliation.'
+
 edit ucb site appearance:
   title: Edit the site appearance
   description: 'Enables editing of the CU Boulder site appearance.'

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -9,10 +9,20 @@ ucb_site_configuration:
   options:
     _admin_route: true
 
+ucb_site_configuration.general_form:
+  path: '/admin/config/cu-boulder/general'
+  defaults:
+    _form: '\Drupal\ucb_site_configuration\Form\GeneralForm'
+    _title: General
+  requirements:
+    _permission: edit ucb site general
+  options:
+    _admin_route: true
+
 ucb_site_configuration.appearance_form:
   path: '/admin/config/cu-boulder/appearance'
   defaults:
-    _form: '\Drupal\ucb_site_configuration\Form\SettingsForm'
+    _form: '\Drupal\ucb_site_configuration\Form\AppearanceForm'
     _title: Appearance
   requirements:
     _permission: edit ucb site appearance


### PR DESCRIPTION
This update to CU Boulder Site Configuration introduces a new "General" configuration form accessible for users with the "Edit the site general settings" permission. The form allows editing of site information:
- Site name
- Site type (optional, selected from a list of presets)
- Site affiliation (optional, selected from a list of presets or custom defined)

The site affiliation is always displayed underneath the site name in the header of the site.

CuBoulder/tiamat-theme#210
CuBoulder/tiamat-theme#211

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/215)