### PR TITLE
Hides administration items that a user doesn't have access to

### DIFF
--- a/src/Controller/SiteSettingsMenuController.php
+++ b/src/Controller/SiteSettingsMenuController.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\ucb_site_configuration\Controller\SiteSettingsMenuController.
+ */
+
+namespace Drupal\ucb_site_configuration\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\ucb_admin_menus\Controller\OverviewController;
+
+class SiteSettingsMenuController extends OverviewController {
+	/**
+	 * Checks if a user can access the "CU Boulder site settings" administration menu.
+	 *
+	 * @param \Drupal\Core\Session\AccountInterface $account
+	 *   The current user.
+	 *
+	 * @return \Drupal\Core\Access\AccessResultInterface
+	 *   The access result.
+	 */
+	public function access(AccountInterface $account) {
+		return AccessResult::allowedIf($account->hasPermission('access administration pages') && ($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site appearance') || $account->hasPermission('edit ucb site contact info') || $account->hasPermission('administer ucb external services')));
+	}
+}

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,9 +2,9 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.2'
+version: '2.2.1'
 package: CU Boulder
 dependencies:
   - block
   - node
-  - system
+  - ucb_admin_menus

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -1,12 +1,12 @@
 ucb_site_configuration:
   path: '/admin/config/cu-boulder'
   defaults:
-    _controller: '\Drupal\ucb_admin_menus\Controller\OverviewController::singleMenuOverview'
+    _controller: '\Drupal\ucb_site_configuration\Controller\SiteSettingsMenuController::singleMenuOverview'
     _title: 'CU Boulder site settings'
     _description: 'Change CU Boulder site-specific settings.'
     link_id: 'ucb_site_configuration'
   requirements:
-    _permission: access administration pages
+    _custom_access: '\Drupal\ucb_site_configuration\Controller\SiteSettingsMenuController::access'
   options:
     _admin_route: true
 

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -1,9 +1,10 @@
 ucb_site_configuration:
   path: '/admin/config/cu-boulder'
   defaults:
-    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _controller: '\Drupal\ucb_admin_menus\Controller\OverviewController::singleMenuOverview'
     _title: 'CU Boulder site settings'
     _description: 'Change CU Boulder site-specific settings.'
+    link_id: 'ucb_site_configuration'
   requirements:
     _permission: access administration pages
   options:


### PR DESCRIPTION
This update includes these changes across several repos:
- Hides inaccessible items from the Admin Toolbar by installing Admin Toolbar Links Access Filter
- Hides inaccessible items from "Add content" and "CU Boulder site settings"

CuBoulder/tiamat-theme#240; Author @TeddyBearX

Sister PRs in: [ucb_admin_menus](https://github.com/CuBoulder/ucb_admin_menus/pull/6), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/32)