### PR TITLE
Adds "Advanced" appearance settings and custom site logos; modifies contact info settings

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -162,21 +162,6 @@ site_affiliation_options:
     label: 'A CU Boulder Sport Club'
     type_restricted: true
 
-editable_theme_settings: 
- - ucb_campus_header_color
- - ucb_header_color
- - ucb_sidebar_position
- # - ucb_be_boulder
- - ucb_rave_alerts
- - ucb_gtm_account
- # - ucb_secondary_menu_default_links
- - ucb_secondary_menu_position
- - ucb_secondary_menu_button_display
- # - ucb_footer_menu_default_links
- - ucb_social_share_position
- - ucb_breadcrumb_nav
- - ucb_date_format
-
 external_services:
   mainstay: 
     label: Mainstay

--- a/config/install/ucb_site_configuration.contact_info.yml
+++ b/config/install/ucb_site_configuration.contact_info.yml
@@ -4,16 +4,12 @@
 
 icons_visible: true
 
-address_visible: false
-address:
+general_visible: false
+general:
   -
     visible: false
     label: ''
-    value: ''
-  -
-    visible: false
-    label: ''
-    value: ''
+    value: { value: '', format: 'wysiwyg' }
 
 email_visible: false
 email:

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -18,8 +18,17 @@ use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\file\Entity\File;
 
 class AppearanceForm extends ThemeSettingsForm {
+
+	/**
+	 * The current user.
+	 *
+	 * @var \Drupal\Core\Session\AccountInterface
+	 */
+	protected $user;
 
 	/**
 	 * The user site configuration service defined in this module.
@@ -43,11 +52,14 @@ class AppearanceForm extends ThemeSettingsForm {
 	 *   The theme manager.
 	 * @param \Drupal\Core\File\FileSystemInterface $file_system
 	 *   The file system.
+	 * @param \Drupal\Core\Session\AccountInterface $user
+	 *   The current user.
 	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
 	 *   The service defined in this module.
 	 */
-	public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler, MimeTypeGuesserInterface $mime_type_guesser, ThemeManagerInterface $theme_manager, FileSystemInterface $file_system, SiteConfiguration $service) {
+	public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler, MimeTypeGuesserInterface $mime_type_guesser, ThemeManagerInterface $theme_manager, FileSystemInterface $file_system, AccountInterface $user, SiteConfiguration $service) {
 		parent::__construct($config_factory, $module_handler, $theme_handler, $mime_type_guesser, $theme_manager, $file_system);
+		$this->user = $user;
 		$this->service = $service;
 	}
 
@@ -67,6 +79,7 @@ class AppearanceForm extends ThemeSettingsForm {
 			$container->get('file.mime_type.guesser'),
 			$container->get('theme.manager'),
 			$container->get('file_system'),
+			$container->get('current_user'),
 			$container->get('ucb_site_configuration')
 		);
 	}
@@ -84,7 +97,81 @@ class AppearanceForm extends ThemeSettingsForm {
 	public function buildForm(array $form, FormStateInterface $form_state, $theme = '') {
 		$theme = $this->service->getThemeName();
 		$form = parent::buildForm($form, $form_state, $theme);
-		unset($form['theme_settings'], $form['logo'], $form['favicon']); // Removes some defaults we don't care about
+		if ($this->user->hasPermission('edit ucb site advanced')) {
+			$advanced = [];
+			$advanced['custom_logo'] = [
+				'#type' => 'container'
+			];
+			$advanced['custom_logo']['ucb_use_custom_logo'] = [
+				'#type' => 'checkbox',
+				'#title' => $this->t('Use a custom logo image'),
+				'#default_value' => theme_get_setting('ucb_use_custom_logo', $theme),
+				'#tree' => FALSE
+			];
+			$advanced['custom_logo']['settings'] = [
+				'#type' => 'container',
+				'#states' => [
+					'visible' => [
+						'input[name="ucb_use_custom_logo"]' => ['checked' => TRUE]
+					]
+				]
+			];
+			$advanced['custom_logo']['settings']['ucb_custom_logo_scale'] = [
+				'#type'  => 'select',
+				'#title' => $this->t('Custom logo scale'),
+				'#description' => $this->t('Define the scale of the custom logo image. E.g. if 2x is selected, upload an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72). Setting this to a higher value ensures the logo always remains sharp on high-resolution devices.'),
+				'#options' => [
+					'1x' => $this->t('1x'),
+					'2x' => $this->t('2x'),
+					'3x' => $this->t('3x')
+				],
+				'#default_value' => theme_get_setting('ucb_custom_logo_scale', $theme) ?? '2x'
+			];
+			$advanced['custom_logo']['settings']['dark'] = [
+				'#type' => 'details',
+				'#title' => $this->t('Custom logo – White text on dark header'),
+				'#description' => $this->t('Provide a logo to use with a dark header. Text in the logo should be legible on dark backgrounds.'),
+				'#open' => TRUE
+			];
+			$advanced['custom_logo']['settings']['light'] = [
+				'#type' => 'details',
+				'#title' => $this->t('Custom logo – Black text on light header'),
+				'#description' => $this->t('Provide a logo to use with a light header. Text in the logo should be legible on light backgrounds.'),
+				'#open' => TRUE
+			];
+			$advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_path'] = [
+				'#type' => 'textfield',
+				'#title' => $this->t('Path to a custom logo'),
+				'#default_value' => theme_get_setting('ucb_custom_logo_dark_path', $theme)
+			];
+			$advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_upload'] = [
+				'#type' => 'managed_file',
+				'#title' => $this->t('Upload a custom logo'),
+				'#description' => $this->t('You may upload a custom logo to use here. The path will be set to the uploaded file automatically when the form is submitted.'),
+				'#multiple' => FALSE,
+				'#upload_location' => 'public://custom_logo/',
+				'#upload_validators' => [
+					'file_validate_is_image' => []
+				]
+			];
+			$advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_path'] = [
+				'#type' => 'textfield',
+				'#title' => $this->t('Path to a custom logo'),
+				'#default_value' => theme_get_setting('ucb_custom_logo_light_path', $theme)
+			];
+			$advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_upload'] = [
+				'#type' => 'managed_file',
+				'#title' => $this->t('Upload a custom logo'),
+				'#description' => $this->t('You may upload a custom logo to use here. The path will be set to the uploaded file automatically when the form is submitted.'),
+				'#multiple' => FALSE,
+				'#upload_location' => 'public://custom_logo/',
+				'#upload_validators' => [
+					'file_validate_is_image' => []
+				]
+			];
+			$form['advanced'] = array_merge($advanced, $form['advanced']);
+		}
+		unset($form['theme_settings'], $form['logo'], $form['favicon']); // Removes some defaults that are normally visible at the top of the theme settings
 		return $form;
 	}
 
@@ -92,8 +179,20 @@ class AppearanceForm extends ThemeSettingsForm {
 	 * {@inheritdoc}
 	 */
 	public function submitForm(array &$form, FormStateInterface $form_state) {
-		// $config = $this->config($this->service->getThemeName() . '.settings');
-		// $values = $form_state->getValues();
+		$fidsDark = $form_state->getValue('ucb_custom_logo_dark_upload');
+		if ($fidsDark && isset($fidsDark[0]) && ($file = File::load($fidsDark[0]))) {
+			$file->setPermanent();
+			$file->save();
+			$form_state->setValue('ucb_custom_logo_dark_path', $file->getFileUri());
+		}
+		$fidsLight = $form_state->getValue('ucb_custom_logo_light_upload');
+		if ($fidsLight && isset($fidsLight[0]) && ($file = File::load($fidsLight[0]))) {
+			$file->setPermanent();
+			$file->save();
+			$form_state->setValue('ucb_custom_logo_light_path', $file->getFileUri());
+		}
+		$form_state->unsetValue('ucb_custom_logo_dark_upload');
+		$form_state->unsetValue('ucb_custom_logo_light_upload');
 		parent::submitForm($form, $form_state);
 	}
 }

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -118,15 +118,7 @@ class AppearanceForm extends ThemeSettingsForm {
 				]
 			];
 			$advanced['custom_logo']['settings']['ucb_custom_logo_scale'] = [
-				'#type'  => 'select',
-				'#title' => $this->t('Custom logo scale'),
-				'#description' => $this->t('Defines the scale of the custom logo image. E.g. if 2x is selected, upload an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72). Setting this to a higher value ensures the logo always remains sharp on high-resolution devices.'),
-				'#options' => [
-					// '1x' => $this->t('1x'),
-					'2x' => $this->t('2x (Retina)'),
-					// '3x' => $this->t('3x (smartphone Retina)')
-				],
-				'#default_value' => theme_get_setting('ucb_custom_logo_scale', $theme) ?? '2x'
+				'#markup' => $this->t('For a custom logo, use an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72).')
 			];
 			$advanced['custom_logo']['settings']['dark'] = [
 				'#type' => 'details',

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -122,9 +122,9 @@ class AppearanceForm extends ThemeSettingsForm {
 				'#title' => $this->t('Custom logo scale'),
 				'#description' => $this->t('Defines the scale of the custom logo image. E.g. if 2x is selected, upload an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72). Setting this to a higher value ensures the logo always remains sharp on high-resolution devices.'),
 				'#options' => [
-					'1x' => $this->t('1x'),
+					// '1x' => $this->t('1x'),
 					'2x' => $this->t('2x (Retina)'),
-					'3x' => $this->t('3x (smartphone Retina)')
+					// '3x' => $this->t('3x (smartphone Retina)')
 				],
 				'#default_value' => theme_get_setting('ucb_custom_logo_scale', $theme) ?? '2x'
 			];
@@ -153,7 +153,7 @@ class AppearanceForm extends ThemeSettingsForm {
 				'#upload_location' => 'public://custom_logo/',
 				'#upload_validators' => [
 					'file_validate_is_image' => [],
-					'file_validate_size' => 2048
+					'file_validate_size' => [2097152] // 2 * 1024 * 1024
 				]
 			];
 			$advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_path'] = [
@@ -169,7 +169,7 @@ class AppearanceForm extends ThemeSettingsForm {
 				'#upload_location' => 'public://custom_logo/',
 				'#upload_validators' => [
 					'file_validate_is_image' => [],
-					'file_validate_size' => 2048
+					'file_validate_size' => [2097152] // 2 * 1024 * 1024
 				]
 			];
 			$form['advanced'] = array_merge($advanced, $form['advanced']);

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -123,8 +123,8 @@ class AppearanceForm extends ThemeSettingsForm {
 				'#description' => $this->t('Defines the scale of the custom logo image. E.g. if 2x is selected, upload an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72). Setting this to a higher value ensures the logo always remains sharp on high-resolution devices.'),
 				'#options' => [
 					'1x' => $this->t('1x'),
-					'2x' => $this->t('2x'),
-					'3x' => $this->t('3x')
+					'2x' => $this->t('2x (Retina)'),
+					'3x' => $this->t('3x (smartphone Retina)')
 				],
 				'#default_value' => theme_get_setting('ucb_custom_logo_scale', $theme) ?? '2x'
 			];
@@ -213,6 +213,7 @@ class AppearanceForm extends ThemeSettingsForm {
 			$this->makePermanent($file);
 		$form_state->unsetValue('ucb_custom_logo_dark_upload');
 		$form_state->unsetValue('ucb_custom_logo_light_upload');
+
 		parent::submitForm($form, $form_state);
 	}
 

--- a/src/Form/ContactInfoForm.php
+++ b/src/Form/ContactInfoForm.php
@@ -107,7 +107,7 @@ class ContactInfoForm extends ConfigFormBase {
 			$fieldDefaultFormat = $value['format'];
 			$fieldDefaultValue = $value['value'];
 		} else $fieldDefaultValue = $value;
-		$field = $form[$machineName . '_' . $index . '_value'] = [
+		$form[$machineName . '_' . $index . '_value'] = [
 			'#type' => $valueFieldType,
 			// '#size' => $valueFieldSize,
 			'#title' => $this->t($valueFieldLabel),
@@ -120,8 +120,8 @@ class ContactInfoForm extends ConfigFormBase {
 				]
 			]
 		];
-		if($fieldDefaultFormat)
-			$field['#format'] = $fieldDefaultFormat;
+		if(isset($fieldDefaultFormat))
+			$form[$machineName . '_' . $index . '_value']['#format'] = $fieldDefaultFormat;
 	}
 
 	/**

--- a/src/Form/ContactInfoForm.php
+++ b/src/Form/ContactInfoForm.php
@@ -32,11 +32,11 @@ class ContactInfoForm extends ConfigFormBase {
 	public function buildForm(array $form, FormStateInterface $form_state) {
 		$config = $this->config('ucb_site_configuration.contact_info');
 		// Toggle for icons
-		$addressStoredValues = $config->get('address');
+		$generalStoredValues = $config->get('general');
 		$emailStoredValues = $config->get('email');
 		$phoneStoredValues = $config->get('phone');
-		if($addressStoredValues)
-			$this->_buildFormSection(sizeof($addressStoredValues), 'Address', 'address', 'address', 'Label (optional)', 'Value (supports multiline)', 'textarea', 255, $addressStoredValues, $form);
+		if($generalStoredValues)
+			$this->_buildFormSection(sizeof($generalStoredValues), 'Contact information', 'contact information', 'general', 'Label (optional)', 'Value', 'text_format', 255, $generalStoredValues, $form);
 		if($emailStoredValues)
 			$this->_buildFormSection(sizeof($emailStoredValues), 'Email address', 'email address', 'email', 'Label (optional)', 'Value', 'email', 20, $emailStoredValues, $form);
 		if($phoneStoredValues)
@@ -59,7 +59,7 @@ class ContactInfoForm extends ConfigFormBase {
 		// Section "Primary x"
 		$sectionForm = [
 			'#type' => 'details',
-			'#title' => 'Primary ' . $verboseNameLower,
+			'#title' => $this->t('Primary ' . $verboseNameLower),
 			'#open' => TRUE,
 			'#states' => [
 				'visible' => [
@@ -80,7 +80,7 @@ class ContactInfoForm extends ConfigFormBase {
 			// Section "[another] x"
 			$subSectionForm = [
 				'#type' => 'details',
-				'#title' => $verboseName,
+				'#title' => $this->t($verboseName),
 				'#open' => TRUE,
 				'#states' => [
 					'visible' => [
@@ -102,11 +102,16 @@ class ContactInfoForm extends ConfigFormBase {
 			'#title' => $this->t($labelFieldLabel),
 			'#default_value' => $storedValues[$index]['label'] ?? ''
 		];
-		$form[$machineName . '_' . $index . '_value'] = [
+		$value = $storedValues[$index]['value'];
+		if(is_array($value)) {
+			$fieldDefaultFormat = $value['format'];
+			$fieldDefaultValue = $value['value'];
+		} else $fieldDefaultValue = $value;
+		$field = $form[$machineName . '_' . $index . '_value'] = [
 			'#type' => $valueFieldType,
 			// '#size' => $valueFieldSize,
 			'#title' => $this->t($valueFieldLabel),
-			'#default_value' => $storedValues[$index]['value'] ?? '',
+			'#default_value' => $fieldDefaultValue,
 			'#states' => [
 				'required' => [
 					':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE],
@@ -115,6 +120,8 @@ class ContactInfoForm extends ConfigFormBase {
 				]
 			]
 		];
+		if($fieldDefaultFormat)
+			$field['#format'] = $fieldDefaultFormat;
 	}
 
 	/**
@@ -124,10 +131,10 @@ class ContactInfoForm extends ConfigFormBase {
 		$formValues = $form_state->getValues();
 		$config = $this->config('ucb_site_configuration.contact_info');
 		$fieldNames = ['visible', 'label', 'value'];
-		$addressStoredValues = $config->get('address');
+		$generalStoredValues = $config->get('general');
 		$emailStoredValues = $config->get('email');
 		$phoneStoredValues = $config->get('phone');
-		$this->_saveFormSection($formValues, $config, 'address', $fieldNames, sizeof($addressStoredValues));
+		$this->_saveFormSection($formValues, $config, 'general', $fieldNames, sizeof($generalStoredValues));
 		$this->_saveFormSection($formValues, $config, 'email', $fieldNames, sizeof($emailStoredValues));
 		$this->_saveFormSection($formValues, $config, 'phone', $fieldNames, sizeof($phoneStoredValues));
 		// Set icons setting and save configuration

--- a/src/Form/ContactInfoForm.php
+++ b/src/Form/ContactInfoForm.php
@@ -103,25 +103,26 @@ class ContactInfoForm extends ConfigFormBase {
 			'#default_value' => $storedValues[$index]['label'] ?? ''
 		];
 		$value = $storedValues[$index]['value'];
-		if(is_array($value)) {
-			$fieldDefaultFormat = $value['format'];
-			$fieldDefaultValue = $value['value'];
-		} else $fieldDefaultValue = $value;
-		$form[$machineName . '_' . $index . '_value'] = [
+		$fieldName = $machineName . '_' . $index . '_value';
+		$form[$fieldName] = [
 			'#type' => $valueFieldType,
 			// '#size' => $valueFieldSize,
 			'#title' => $this->t($valueFieldLabel),
-			'#default_value' => $fieldDefaultValue,
+			'#default_value' => is_array($value) ? $value['value'] : $value,
 			'#states' => [
 				'required' => [
-					':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE],
-					'and',
-					':input[name="' . $machineName . '_' . $index . '_visible"]' => ['checked' => TRUE]
+					':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE]
 				]
 			]
 		];
-		if(isset($fieldDefaultFormat))
-			$form[$machineName . '_' . $index . '_value']['#format'] = $fieldDefaultFormat;
+		if ($valueFieldType == 'text_format') {
+			$form[$fieldName]['#format'] = $value['format'] ?? '';
+			$form[$fieldName]['#base_type'] = 'textarea';
+			$form[$fieldName]['#states']['required'] = [];
+		} else if ($index > 0) {
+			$form[$fieldName]['#states']['required'][] = 'and';
+			$form[$fieldName]['#states']['required'][':input[name="' . $machineName . '_' . $index . '_visible"]'] = ['checked' => TRUE];
+		}
 	}
 
 	/**

--- a/src/Plugin/Block/SiteInfoBlock.php
+++ b/src/Plugin/Block/SiteInfoBlock.php
@@ -27,8 +27,8 @@ class SiteInfoBlock extends BlockBase {
 		return [
 			'#data' => [
 				'icons_visible' => $config->get('icons_visible'),
-				'address_visible' => $config->get('address_visible'),
-				'address' => $config->get('address'),
+				'general_visible' => $config->get('general_visible'),
+				'general' => $config->get('general'),
 				'email_visible' => $config->get('email_visible'),
 				'email' => $config->get('email'),
 				'phone_visible' => $config->get('phone_visible'),

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -13,7 +13,6 @@ use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationManager;
 use Drupal\node\NodeInterface;
@@ -272,32 +271,6 @@ class SiteConfiguration {
 				'#default_value'  => theme_get_setting('ucb_footer_menu_default_links', $themeName),
 				'#description'    => $this->t('Check this box if you would like to display the default Boulder footer menu links in the footer.')
 			];
-		}
-	}
-
-	/**
-	 * Builds the inner settings form for an external service on a node add or edit page.
-	 * 
-	 * @param array &$form
-	 *   The form build array.
-	 * @param string $externalServiceName
-	 *   The machine name of the external srvice.
-	 * @param \Drupal\node\NodeInterface $node
-	 *   The node for which this form is being built.
-	 * @param FormStateInterface $form_state
-	 *   The current state of the form.
-	 */
-	public function buildExternalServiceContentSettingsForm(array &$form, $externalServiceName, NodeInterface $node, FormStateInterface $form_state) {
-		switch ($externalServiceName) {
-			case 'mainstay':
-				$form['ucb_external_service_' . $externalServiceName . '__college_id'] = [
-					'#type' => 'textfield',
-					'#size' => '60',
-					'#title' => $this->t('College ID'),
-					// '#default_value' => $node->get('ucb_external_service_' . $externalServiceName . '__college_id')
-				];
-			break;
-			default:
 		}
 	}
 

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -6,6 +6,7 @@ version: '2.3'
 package: CU Boulder
 dependencies:
   - block
+  - file
   - node
   - ucb_admin_menus
   - system

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,9 +2,10 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.2.1'
+version: '2.3'
 package: CU Boulder
 dependencies:
   - block
   - node
   - ucb_admin_menus
+  - system

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -33,3 +33,20 @@ function ucb_site_configuration_update_9503() {
 function ucb_site_configuration_update_9504() {
 	\Drupal::configFactory()->getEditable('ucb_site_configuration.configuration')->clear('admin_helpscout_beacon_id')->save();
 }
+
+/**
+ * v2.3 – Modififies contact info settings (CuBoulder/tiamat-theme#269).
+ */
+function ucb_site_configuration_update_9505() {
+	\Drupal::configFactory()->getEditable('ucb_site_configuration.contact_info')
+		->clear('address_visible')
+		->clear('address')
+		->set('general_visible', FALSE)
+		->set('general', [
+			[
+				'visible' => FALSE,
+				'label' => '',
+				'value' => [ 'value' => '', 'format' => 'wysiwyg' ]
+			]])
+		->save();
+}

--- a/ucb_site_configuration.permissions.yml
+++ b/ucb_site_configuration.permissions.yml
@@ -13,3 +13,7 @@ edit ucb site contact info:
 administer ucb external services:
   title: Administer third-party services
   description: 'Enables adding, editing, and deleting supported third-party services.'
+
+edit ucb site advanced:
+  title: Edit advanced site settings
+  description: 'Enables editing of advanced CU Boulder site settings that are typically meant for support and development staff only.'

--- a/ucb_site_configuration.services.yml
+++ b/ucb_site_configuration.services.yml
@@ -8,3 +8,5 @@ services:
       - '@string_translation'
       - '@entity_type.manager'
       - '@entity_type.repository'
+      - '@current_route_match'
+      - '@messenger'


### PR DESCRIPTION
This update:
- Adds an _Advanced_ view at the bottom of the _Appearance_ settings, collapsed by default and visible only to those with the _Edit advanced site settings_ permission.
- Moves all theme settings previously restricted to Drupal's default theme settings into the _Advanced_ view.
- Adds site-specific custom logos (CuBoulder/tiamat-theme#264) and places the settings for custom logos into the _Advanced_ view:
  - Custom logo requires _white text on dark header_ and _dark text on white header_ variants.
  - An image can be uploaded or a path can be manually specified for each.
  - ~~A scale can be specified, which defaults to _2x_ (Retina) but also allows _1x_ (standard) or _3x_ (enhanced Retina)~~.
- Assigns the _Architect_ and _Developer_ user roles the _Edit advanced site settings_ permission.
- Replaces address fields with general field and WYSIWYG editor in site contact info; removes colons from site contact info footer (CuBoulder/tiamat-theme#269)

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/270), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/34)