### PR TITLE
Adds a global "Related articles" configuration form to CU Boulder Site Settings

### DIFF
--- a/config/install/ucb_site_configuration.settings.yml
+++ b/config/install/ucb_site_configuration.settings.yml
@@ -5,5 +5,6 @@ site_affiliation: ''
 site_affiliation_label: ''
 site_affiliation_url: ''
 
+related_articles_enabled_by_default: FALSE
 related_articles_exclude_categories: []
 related_articles_exclude_tags: []

--- a/config/install/ucb_site_configuration.settings.yml
+++ b/config/install/ucb_site_configuration.settings.yml
@@ -4,3 +4,6 @@ site_type: ''
 site_affiliation: ''
 site_affiliation_label: ''
 site_affiliation_url: ''
+
+related_articles_exclude_categories: []
+related_articles_exclude_tags: []

--- a/src/Form/ExternalServiceIncludeEntityForm.php
+++ b/src/Form/ExternalServiceIncludeEntityForm.php
@@ -232,7 +232,7 @@ class ExternalServiceIncludeEntityForm extends EntityForm {
 					'#size' => 24,
 					'#maxlength' => 24,
 					'#title' => $this->t('Bot token'),
-					'#default_value' => $externalServiceSettings['bot_token'],
+					'#default_value' => $externalServiceSettings['bot_token'] ?? '',
 					'#states' => [
 						'required' => [
 							':input[name="service_name"]' => ['value' => $externalServiceName]
@@ -244,7 +244,7 @@ class ExternalServiceIncludeEntityForm extends EntityForm {
 					'#size' => 64,
 					'#maxlength' => 64,
 					'#title' => $this->t('College ID'),
-					'#default_value' => $externalServiceSettings['college_id'],
+					'#default_value' => $externalServiceSettings['college_id'] ?? '',
 					'#states' => [
 						'required' => [
 							':input[name="service_name"]' => ['value' => $externalServiceName]
@@ -258,7 +258,7 @@ class ExternalServiceIncludeEntityForm extends EntityForm {
 					'#size' => 12,
 					'#maxlength' => 12,
 					'#title' => $this->t('License ID'),
-					'#default_value' => $externalServiceSettings['license_id'],
+					'#default_value' => $externalServiceSettings['license_id'] ?? '',
 					'#states' => [
 						'required' => [
 							':input[name="service_name"]' => ['value' => $externalServiceName]
@@ -272,7 +272,7 @@ class ExternalServiceIncludeEntityForm extends EntityForm {
 					'#size' => 12,
 					'#maxlength' => 12,
 					'#title' => $this->t('Page ID'),
-					'#default_value' => $externalServiceSettings['page_id'],
+					'#default_value' => $externalServiceSettings['page_id'] ?? '',
 					'#states' => [
 						'required' => [
 							':input[name="service_name"]' => ['value' => $externalServiceName]

--- a/src/Form/GeneralForm.php
+++ b/src/Form/GeneralForm.php
@@ -132,7 +132,6 @@ class GeneralForm extends ConfigFormBase {
 	 */
 	public function submitForm(array &$form, FormStateInterface $form_state) {
 		$configuration = $this->service->getConfiguration();
-		$settings = $this->config('ucb_site_configuration.settings');
 		$siteTypeOptions = $configuration->get('site_type_options');
 		$this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
 		$siteTypeId = $form_state->getValue('site_type');

--- a/src/Form/RelatedArticlesForm.php
+++ b/src/Form/RelatedArticlesForm.php
@@ -86,6 +86,13 @@ class RelatedArticlesForm extends ConfigFormBase {
 			$categoryOptions[$categoryTerm->id()] = $categoryTerm->label();
 		foreach ($tagTerms as $tagTerm)
 			$tagOptions[$tagTerm->id()] = $tagTerm->label();
+		$form['enabled_by_default'] = [
+			'#type' => 'checkbox',
+			'#title' => $this->t('Enable related articles by default for new articles'),
+			'#description' => $this->t('If enabled, related articles will default to on when creating a new article. A content author may still turn on or off related articles manually for an individual article.'),
+			'#default_value' => $settings->get('related_articles_enabled_by_default') ?? FALSE,
+			'#required' => FALSE
+		];
 		$form['exclude_categories'] = [
 			'#type' => 'checkboxes',
 			'#title' => $this->t('Exclude categories'),
@@ -108,6 +115,7 @@ class RelatedArticlesForm extends ConfigFormBase {
 	 */
 	public function submitForm(array &$form, FormStateInterface $form_state) {
 		$this->config('ucb_site_configuration.settings')
+			->set('related_articles_enabled_by_default', $form_state->getValue('enabled_by_default'))
 			->set('related_articles_exclude_categories', array_keys(array_filter($form_state->getValue('exclude_categories'))))
 			->set('related_articles_exclude_tags', array_keys(array_filter($form_state->getValue('exclude_tags'))))
 			->save();

--- a/src/Form/RelatedArticlesForm.php
+++ b/src/Form/RelatedArticlesForm.php
@@ -107,10 +107,9 @@ class RelatedArticlesForm extends ConfigFormBase {
 	 * {@inheritdoc}
 	 */
 	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$formValues = $form_state->getValues();
 		$this->config('ucb_site_configuration.settings')
-			->set('related_articles_exclude_categories', $form_state->getValue('exclude_categories'))
-			->set('related_articles_exclude_tags', $form_state->getValue('exclude_tags'))
+			->set('related_articles_exclude_categories', array_keys(array_filter($form_state->getValue('exclude_categories'))))
+			->set('related_articles_exclude_tags', array_keys(array_filter($form_state->getValue('exclude_tags'))))
 			->save();
 		parent::submitForm($form, $form_state);
 	}

--- a/src/Form/RelatedArticlesForm.php
+++ b/src/Form/RelatedArticlesForm.php
@@ -8,11 +8,19 @@
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RelatedArticlesForm extends ConfigFormBase {
+
+	/**
+	 * The entity type manager.
+	 *
+	 * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+	 */
+	protected $entityTypeManager;
 
 	/**
 	 * The user site configuration service defined in this module.
@@ -22,12 +30,16 @@ class RelatedArticlesForm extends ConfigFormBase {
 	protected $service;
 
 	/**
-	 * Constructs an ExternalServiceIncludeEntityForm object.
+	 * Constructs a RelatedArticlesForm object.
+	 * 
+	 * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   	 *   The entity type manager.
 	 * 
 	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
 	 *   The service defined in this module.
 	 */
-	public function __construct(SiteConfiguration $service) {
+	public function __construct(EntityTypeManagerInterface $entityTypeManager, SiteConfiguration $service) {
+		$this->entityTypeManager = $entityTypeManager;
 		$this->service = $service;
 	}
 
@@ -41,6 +53,7 @@ class RelatedArticlesForm extends ConfigFormBase {
 	 */
 	public static function create(ContainerInterface $container) {
 		return new static(
+			$container->get('entity_type.manager'),
 			$container->get('ucb_site_configuration')
 		);
 	}
@@ -64,7 +77,29 @@ class RelatedArticlesForm extends ConfigFormBase {
 	 */
 	public function buildForm(array $form, FormStateInterface $form_state) {
 		$settings = $this->service->getSettings();
-		// TODO
+		$entityStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+		$categoryTerms = $entityStorage->loadByProperties(['vid' => 'category']);
+		$categoryOptions = [];
+		$tagTerms = $entityStorage->loadByProperties(['vid' => 'tags']);
+		$tagOptions = [];
+		foreach ($categoryTerms as $categoryTerm)
+			$categoryOptions[$categoryTerm->id()] = $categoryTerm->label();
+		foreach ($tagTerms as $tagTerm)
+			$tagOptions[$tagTerm->id()] = $tagTerm->label();
+		$form['exclude_categories'] = [
+			'#type' => 'checkboxes',
+			'#title' => $this->t('Exclude categories'),
+			'#default_value' => $settings->get('related_articles_exclude_categories') ?? [],
+			'#options' => $categoryOptions,
+			'#required' => FALSE
+		];
+		$form['exclude_tags'] = [
+			'#type' => 'checkboxes',
+			'#title' => $this->t('Exclude tags'),
+			'#default_value' => $settings->get('related_articles_exclude_tags') ?? [],
+			'#options' => $tagOptions,
+			'#required' => FALSE
+		];
 		return parent::buildForm($form, $form_state);
 	}
 
@@ -72,6 +107,11 @@ class RelatedArticlesForm extends ConfigFormBase {
 	 * {@inheritdoc}
 	 */
 	public function submitForm(array &$form, FormStateInterface $form_state) {
-		// TODO
+		$formValues = $form_state->getValues();
+		$this->config('ucb_site_configuration.settings')
+			->set('related_articles_exclude_categories', $form_state->getValue('exclude_categories'))
+			->set('related_articles_exclude_tags', $form_state->getValue('exclude_tags'))
+			->save();
+		parent::submitForm($form, $form_state);
 	}
 }

--- a/src/Form/RelatedArticlesForm.php
+++ b/src/Form/RelatedArticlesForm.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\ucb_site_configuration\Form\RelatedArticlesForm.
+ */
+
+namespace Drupal\ucb_site_configuration\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ucb_site_configuration\SiteConfiguration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class RelatedArticlesForm extends ConfigFormBase {
+
+	/**
+	 * The user site configuration service defined in this module.
+	 *
+	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
+	 */
+	protected $service;
+
+	/**
+	 * Constructs an ExternalServiceIncludeEntityForm object.
+	 * 
+	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+	 *   The service defined in this module.
+	 */
+	public function __construct(SiteConfiguration $service) {
+		$this->service = $service;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+	 *   The container that allows getting any needed services.
+	 *
+	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
+	 */
+	public static function create(ContainerInterface $container) {
+		return new static(
+			$container->get('ucb_site_configuration')
+		);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFormId() {
+		return 'ucb_site_configuration_related_articles_form';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getEditableConfigNames() {
+		return ['ucb_site_configuration.settings'];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function buildForm(array $form, FormStateInterface $form_state) {
+		$settings = $this->service->getSettings();
+		// TODO
+		return parent::buildForm($form, $form_state);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function submitForm(array &$form, FormStateInterface $form_state) {
+		// TODO
+	}
+}

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -316,6 +316,18 @@ class SiteConfiguration {
 	}
 
 	/**
+	 * This helper function attaches related articles configuration to Articles.
+	 * 
+	 * @param array &$variables
+	 *   The array to add the site information to.
+	 */
+	public function attachRelatedArticlesConfiguration(array &$variables) {
+		$settings = $this->getSettings();
+		$variables['related_articles_exclude_categories'] = $settings->get('related_articles_exclude_categories') ?? [];
+		$variables['related_articles_exclude_tags'] = $settings->get('related_articles_exclude_tags') ?? [];
+	}
+
+	/**
 	 * This helper function attaches external service includes if called from hook_preprocess in the .module file.
 	 * Variables can be referenced from the template using `service_servicename_includes`.
 	 * 

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.3'
+version: '2.4'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_site_configuration.links.menu.yml
+++ b/ucb_site_configuration.links.menu.yml
@@ -23,9 +23,15 @@ ucb_site_configuration.contact_info_form:
   route_name: ucb_site_configuration.contact_info_form
   parent: ucb_site_configuration
   weight: 2
+ucb_site_configuration.related_articles_form:
+  title: Related articles
+  description: 'Exclude categories or tags from related articles.'
+  route_name: ucb_site_configuration.related_articles_form
+  parent: ucb_site_configuration
+  weight: 3
 ucb_site_configuration.external_services:
   title: Third-party services
   description: 'Configure third-party services to be used on the site.'
   route_name: entity.ucb_external_service_include.collection
   parent: ucb_site_configuration
-  weight: 3
+  weight: 4

--- a/ucb_site_configuration.links.task.yml
+++ b/ucb_site_configuration.links.task.yml
@@ -13,8 +13,13 @@ ucb_site_configuration.contact_info_form:
   title: 'Contact info'
   base_route: ucb_site_configuration
   weight: 2
+ucb_site_configuration.related_articles_form:
+  route_name: ucb_site_configuration.related_articles_form
+  title: 'Related articles'
+  base_route: ucb_site_configuration
+  weight: 3
 ucb_site_configuration.external_services:
   route_name: entity.ucb_external_service_include.collection
   title: 'Third-party services'
   base_route: ucb_site_configuration
-  weight: 3
+  weight: 4

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
@@ -23,7 +25,7 @@ function ucb_site_configuration_preprocess_page(array &$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function ucb_site_configuration_preprocess_node(array &$variables) {
-	/** @var \Drupal\node\NodeInterface $node */
+	/** @var \Drupal\node\NodeInterface */
 	$node = $variables['node'];
 	if ($node->getType() === 'ucb_article') {
 		\Drupal::service('ucb_site_configuration')->attachRelatedArticlesConfiguration($variables);
@@ -32,13 +34,22 @@ function ucb_site_configuration_preprocess_node(array &$variables) {
 }
 
 /**
- * Adds third-party service configuration options to node form sidebars.
+ * Sets related articles setting to the global setting by default.
+ * Implements hook_field_widget_single_element_form_alter().  
+ */  
+function ucb_site_configuration_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+	if ($context['items']->getFieldDefinition()->getName() === 'field_ucb_related_articles_parag' && !$form_state->getFormObject()->getEntity()->id())
+		$element['subform']['field_ucb_related_articles_bool']['widget']['value']['#default_value'] = \Drupal::service('ucb_site_configuration')->getSettings()->get('related_articles_enabled_by_default') ?? FALSE;	
+}
+
+/**
+ * Adds configuration options to node form sidebars.
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInterface $form_state) {
 	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
 	$service = \Drupal::service('ucb_site_configuration');
-	/** @var \Drupal\node\NodeInterface $node */
+	/** @var \Drupal\node\NodeInterface */
 	$node = $form_state->getFormObject()->getEntity();
 	$contentAccessibleExternalServiceIncludes = $service->getContentAccessibleExternalServiceIncludes();
 	$contentServicesFieldAllowedOptions = [];
@@ -51,7 +62,7 @@ function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInte
 	}
 	/** @var \Symfony\Component\Routing\Route */
     $siteSettingsRoute = \Drupal::service('router.route_provider')->getRouteByName('entity.ucb_external_service_include.collection');
-	$form['ucb_external_services'] = [
+	$form['ucb_external_services'] = [ // Adds third-party service includes to node sidebar
 		'#type' => 'details',
    		'#title' => t('Third-party services'),
 		'#group' => 'advanced',

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -19,6 +19,17 @@ function ucb_site_configuration_preprocess_page(array &$variables) {
 }
 
 /**
+ * Exposes related article configuration to the Article node template.
+ * Implements hook_preprocess_HOOK().
+ */
+function ucb_site_configuration_preprocess_node(array &$variables) {
+	/** @var \Drupal\node\NodeInterface $node */
+	$node = $variables['node'];
+	if ($node->getType() == 'ucb_article')
+		\Drupal::service('ucb_site_configuration')->attachRelatedArticlesConfiguration($variables);
+}
+
+/**
  * Adds third-party service configuration options to node form sidebars.
  * Implements hook_form_BASE_FORM_ID_alter().
  */

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -25,8 +25,10 @@ function ucb_site_configuration_preprocess_page(array &$variables) {
 function ucb_site_configuration_preprocess_node(array &$variables) {
 	/** @var \Drupal\node\NodeInterface $node */
 	$node = $variables['node'];
-	if ($node->getType() == 'ucb_article')
+	if ($node->getType() === 'ucb_article') {
 		\Drupal::service('ucb_site_configuration')->attachRelatedArticlesConfiguration($variables);
+		$variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
+	}
 }
 
 /**

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -1,7 +1,5 @@
 <?php
 
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
@@ -43,7 +41,7 @@ function ucb_site_configuration_field_widget_single_element_form_alter(array &$e
 }
 
 /**
- * Adds configuration options to node form sidebars.
+ * Adds third-party service configuration options to node form sidebars.
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInterface $form_state) {
@@ -62,7 +60,7 @@ function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInte
 	}
 	/** @var \Symfony\Component\Routing\Route */
     $siteSettingsRoute = \Drupal::service('router.route_provider')->getRouteByName('entity.ucb_external_service_include.collection');
-	$form['ucb_external_services'] = [ // Adds third-party service includes to node sidebar
+	$form['ucb_external_services'] = [
 		'#type' => 'details',
    		'#title' => t('Third-party services'),
 		'#group' => 'advanced',

--- a/ucb_site_configuration.permissions.yml
+++ b/ucb_site_configuration.permissions.yml
@@ -10,6 +10,10 @@ edit ucb site contact info:
   title: Edit the site contact info
   description: 'Enables editing of the CU Boulder site contact info.'
 
+configure ucb related articles:
+  title: Configure related articles
+  description: 'Exclude categories or tags from related articles.'
+
 administer ucb external services:
   title: Administer third-party services
   description: 'Enables adding, editing, and deleting supported third-party services.'

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -40,6 +40,16 @@ ucb_site_configuration.contact_info_form:
   options:
     _admin_route: true
 
+ucb_site_configuration.related_articles_form:
+  path: '/admin/config/cu-boulder/related-articles'
+  defaults:
+    _form: '\Drupal\ucb_site_configuration\Form\RelatedArticlesForm'
+    _title: Related articles
+  requirements:
+    _permission: configure ucb related articles
+  options:
+    _admin_route: true
+
 entity.ucb_external_service_include.collection:
   path: '/admin/config/cu-boulder/services'
   defaults:


### PR DESCRIPTION
This update adds a "Related articles" configuration form to CU Boulder Site Settings, accessible via the menu or `/admin/config/cu-boulder/related-articles`. Here users with permission can exclude articles with specific categories or tags from appearing in "related articles" sections. Resolves CuBoulder/ucb_site_configuration#22

This update also fixes a bug which caused warnings to appear when configuring a third-party service. Resolves CuBoulder/ucb_site_configuration#21

Sister PR in: [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/47), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/7)