### PR TITLE
Removes "D9" from theme name and the theme, custom entities Composer package names

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -118,7 +118,7 @@ class SiteConfiguration {
 	 *   The machine name of the CU Boulder base theme to configure.
 	 */
 	public function getThemeName() {
-		return 'boulderD9_base';
+		return 'boulder_base';
 	}
 
 	/**


### PR DESCRIPTION
CuBoulder/tiamat-theme#435

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/452), [tiamat-custom-entities](https://github.com/CuBoulder/tiamat-custom-entities/pull/70), [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/52), [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/13), [tiamat-project-template](https://github.com/CuBoulder/tiamat-project-template/pull/28), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/8)