### PR TITLE
Adds home page setting to CU Boulder site settings

### DIFF
--- a/src/Controller/ExternalServiceIncludeListBuilder.php
+++ b/src/Controller/ExternalServiceIncludeListBuilder.php
@@ -22,7 +22,7 @@ class ExternalServiceIncludeListBuilder extends ConfigEntityListBuilder {
   protected $service;
 
   /**
-   * Constructs a new ExternalServiceIncludeListBuilder object.
+   * Constructs an ExternalServiceIncludeListBuilder object.
    *
    * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
    *   The entity type definition.

--- a/src/Controller/ExternalServiceIncludeListBuilder.php
+++ b/src/Controller/ExternalServiceIncludeListBuilder.php
@@ -2,70 +2,73 @@
 
 namespace Drupal\ucb_site_configuration\Controller;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * The page for the "Third-party services" tab in CU Boulder site settings.
+ */
 class ExternalServiceIncludeListBuilder extends ConfigEntityListBuilder {
 
-	/**
-	 * The site configuration service defined in this module.
-	 *
-	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
-	 */
-	protected $service;
+  /**
+   * The site configuration service defined in this module.
+   *
+   * @var \Drupal\ucb_site_configuration\SiteConfiguration
+   */
+  protected $service;
 
-	/**
-	 * Constructs a new ExternalServiceIncludeListBuilder object.
-	 *
-	 * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-	 *   The entity type definition.
-	 * @param \Drupal\Core\Entity\EntityStorageInterface $storage
-	 *   The entity storage class.
-	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
-	 *   The site configuration service defined in this module.
-	 */
-	public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, SiteConfiguration $service) {
-		parent::__construct($entity_type, $storage);
-		$this->service = $service;
-	}
+  /**
+   * Constructs a new ExternalServiceIncludeListBuilder object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   *   The entity storage class.
+   * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+   *   The site configuration service defined in this module.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, SiteConfiguration $service) {
+    parent::__construct($entity_type, $storage);
+    $this->service = $service;
+  }
 
-	/**
-   	* {@inheritdoc}
-   	*/
-	public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
-		return new static(
-			$entity_type,
-			$container->get('entity_type.manager')->getStorage($entity_type->id()),
-			$container->get('ucb_site_configuration')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+    $entity_type,
+    $container->get('entity_type.manager')->getStorage($entity_type->id()),
+    $container->get('ucb_site_configuration')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function buildHeader() {
-		$header['service_name'] = $this->t('Service');
-		$header['label'] = $this->t('Label');
-		$header['included_on'] = $this->t('Included on');
-		return $header + parent::buildHeader();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['service_name'] = $this->t('Service');
+    $header['label'] = $this->t('Label');
+    $header['included_on'] = $this->t('Included on');
+    return $header + parent::buildHeader();
+  }
 
-	/**
-	 * {@inheritdoc}
-	 * 
-	 * @param \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface $entity
-	 *   The ExternalServiceInclude entity.
-	 */
-	public function buildRow(EntityInterface $entity) {
-		$externalServiceConfiguration = $this->service->getConfiguration()->get('external_services')[$entity->getServiceName()];
-		$row['service_name'] = $externalServiceConfiguration['label'] ?? $entity->getServiceName();
-		$row['label'] = $entity->label();
-		$row['included_on'] = $entity->isSitewide() ? $this->t('All pages') : $this->formatPlural(count($entity->getNodes()), '1 page', '@count pages');
-		return $row + parent::buildRow($entity);
-	}
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface $entity
+   *   The ExternalServiceInclude entity.
+   */
+  public function buildRow(EntityInterface $entity) {
+    $externalServiceConfiguration = $this->service->getConfiguration()->get('external_services')[$entity->getServiceName()];
+    $row['service_name'] = $externalServiceConfiguration['label'] ?? $entity->getServiceName();
+    $row['label'] = $entity->label();
+    $row['included_on'] = $entity->isSitewide() ? $this->t('All pages') : $this->formatPlural(count($entity->getNodes()), '1 page', '@count pages');
+    return $row + parent::buildRow($entity);
+  }
+
 }

--- a/src/Controller/SiteSettingsAccessController.php
+++ b/src/Controller/SiteSettingsAccessController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\ucb_site_configuration\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * The access controller for the individual tabs of CU Boulder site settings.
+ *
+ * Tabs that only require one access permission need not be defined here, as the
+ * permission can instead be defined in `ucb_site_configuration.routing.yml`.
+ */
+class SiteSettingsAccessController {
+
+  /**
+   * Gets an access result for the "General" tab.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account interface of the requesting user.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result for the "General" tab of CU Boulder site settings.
+   */
+  public function accessGeneral(AccountInterface $account) {
+    return AccessResult::allowedIf($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site pages'));
+  }
+
+}

--- a/src/Controller/SiteSettingsMenuController.php
+++ b/src/Controller/SiteSettingsMenuController.php
@@ -7,7 +7,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\ucb_admin_menus\Controller\OverviewController;
 
 /**
- * The access controller for the "CU Boulder site settings" administration menu.
+ * The controller for the "CU Boulder site settings" administration menu.
  */
 class SiteSettingsMenuController extends OverviewController {
 
@@ -15,7 +15,7 @@ class SiteSettingsMenuController extends OverviewController {
    * {@inheritdoc}
    */
   public function access(AccountInterface $account) {
-    return AccessResult::allowedIf($account->hasPermission('access administration pages') && ($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site appearance') || $account->hasPermission('edit ucb site contact info') || $account->hasPermission('administer ucb external services')));
+    return AccessResult::allowedIf($account->hasPermission('access administration pages') && ($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site pages') || $account->hasPermission('edit ucb site appearance') || $account->hasPermission('edit ucb site contact info') || $account->hasPermission('administer ucb external services')));
   }
 
 }

--- a/src/Controller/SiteSettingsMenuController.php
+++ b/src/Controller/SiteSettingsMenuController.php
@@ -1,27 +1,21 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\ucb_site_configuration\Controller\SiteSettingsMenuController.
- */
-
 namespace Drupal\ucb_site_configuration\Controller;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\ucb_admin_menus\Controller\OverviewController;
 
+/**
+ * The access controller for the "CU Boulder site settings" administration menu.
+ */
 class SiteSettingsMenuController extends OverviewController {
-	/**
-	 * Checks if a user can access the "CU Boulder site settings" administration menu.
-	 *
-	 * @param \Drupal\Core\Session\AccountInterface $account
-	 *   The current user.
-	 *
-	 * @return \Drupal\Core\Access\AccessResultInterface
-	 *   The access result.
-	 */
-	public function access(AccountInterface $account) {
-		return AccessResult::allowedIf($account->hasPermission('access administration pages') && ($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site appearance') || $account->hasPermission('edit ucb site contact info') || $account->hasPermission('administer ucb external services')));
-	}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    return AccessResult::allowedIf($account->hasPermission('access administration pages') && ($account->hasPermission('edit ucb site general') || $account->hasPermission('edit ucb site appearance') || $account->hasPermission('edit ucb site contact info') || $account->hasPermission('administer ucb external services')));
+  }
+
 }

--- a/src/Entity/ExternalServiceInclude.php
+++ b/src/Entity/ExternalServiceInclude.php
@@ -1,18 +1,17 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\ucb_site_configuration\Entity\ExternalServiceInclude.
- */
-
 namespace Drupal\ucb_site_configuration\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
 use Drupal\node\Entity\Node;
 
 /**
- * Defines the ExternalServiceInclude entity.
- * 
+ * The entity used to add a node-level third-party service service to a site.
+ *
+ * This is distinct from block-level third-party services, or third-party
+ * services such as Google Maps that can be added from a plugin in the
+ * WYSIWYG editor, which aren't handled by this module.
+ *
  * @ConfigEntityType(
  *  id = "ucb_external_service_include",
  *  label = @Translation("Third-party service"),
@@ -22,7 +21,7 @@ use Drupal\node\Entity\Node;
  *   "form" = {
  *    "add" = "Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityForm",
  *    "edit" = "Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityForm",
- *    "delete" = "Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityDeleteForm" 
+ *    "delete" = "Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityDeleteForm"
  *   }
  *  },
  *  config_prefix = "external_service_includes",
@@ -55,90 +54,95 @@ use Drupal\node\Entity\Node;
  */
 class ExternalServiceInclude extends ConfigEntityBase implements ExternalServiceIncludeInterface {
 
-	/**
-	 * The machine name of this include.
-	 *
-	 * @var string
-	 */
-	protected $id = '';
+  /**
+   * The machine name of this include.
+   *
+   * @var string
+   */
+  protected $id = '';
 
-	/**
-	 * The label of this include.
-	 *
-	 * @var string
-	 */
-	protected $label = '';
+  /**
+   * The label of this include.
+   *
+   * @var string
+   */
+  protected $label = '';
 
-	/**
-	 * The name of the service of this include.
-	 *
-	 * @var string
-	 */
-	protected $service_name = '';
+  /**
+   * The name of the service of this include.
+   *
+   * @var string
+   */
+  protected $service_name = '';
 
-	/**
-	 * The settings of the service of this include.
-	 *
-	 * @var array
-	 */
-	protected $service_settings = [];
+  /**
+   * The settings of the service of this include.
+   *
+   * @var array
+   */
+  protected $service_settings = [];
 
-	/**
-	 * True if this include applies to the entire site rather than specific nodes.
-	 */
-	protected $sitewide = FALSE;
+  /**
+   * True if this include applies to the entire site rather than specific nodes.
+   *
+   * @var bool
+   */
+  protected $sitewide = FALSE;
 
-	/**
-	 * True if this include can be added or removed by content authors.
-	 */
-	protected $content_editing_enabled = TRUE;
+  /**
+   * True if this include can be added or removed by content authors.
+   *
+   * @var bool
+   */
+  protected $content_editing_enabled = TRUE;
 
-	/**
-	 * The ids for nodes that this include applies to.
-	 *
-	 * @var string[]
-	 */
-	protected $nodes = [];
+  /**
+   * The ids for nodes that this include applies to.
+   *
+   * @var string[]
+   */
+  protected $nodes = [];
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getServiceName() {
-		return $this->service_name;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getServiceName() {
+    return $this->service_name;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getServiceSettings() {
-		return $this->service_settings;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getServiceSettings() {
+    return $this->service_settings;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function isSitewide() {
-		return (bool) $this->sitewide;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function isSitewide() {
+    return (bool) $this->sitewide;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function isContentEditingEnabled() {
-		return (bool) $this->content_editing_enabled;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function isContentEditingEnabled() {
+    return (bool) $this->content_editing_enabled;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getNodeIds() {
-		return $this->nodes;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getNodeIds() {
+    return $this->nodes;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getNodes() {
-		return Node::loadMultiple($this->nodes);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getNodes() {
+    return Node::loadMultiple($this->nodes);
+  }
+
 }

--- a/src/Entity/ExternalServiceIncludeInterface.php
+++ b/src/Entity/ExternalServiceIncludeInterface.php
@@ -1,62 +1,83 @@
 <?php
 
-/**
- * @file
- * Contains Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface.
- */
-
 namespace Drupal\ucb_site_configuration\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 
+/**
+ * The entity used to add a node-level third-party service service to a site.
+ *
+ * This is distinct from block-level third-party services, or third-party
+ * services such as Google Maps that can be added from a plugin in the
+ * WYSIWYG editor, which aren't handled by this module.
+ */
 interface ExternalServiceIncludeInterface extends ConfigEntityInterface {
 
-	/**
-     * @return string
-	 *   The machine name of this include.
-	 */
-	public function id();
+  /**
+   * Gets the machine name of this include.
+   *
+   * @return string
+   *   The machine name of this include.
+   */
+  public function id();
 
-	/**
-	 * @return string
-	 *   The label of this include.
-	 */
-	public function label();
+  /**
+   * Gets the label of this include.
+   *
+   * @return string
+   *   The label of this include.
+   */
+  public function label();
 
-	/**
-	 * @return string
-	 *   The name of the service this include is intended to provide.
-	 */
-	public function getServiceName();
+  /**
+   * Gets the name of the service this include is intended to provide.
+   *
+   * @return string
+   *   The name of the service this include is intended to provide.
+   */
+  public function getServiceName();
 
+  /**
+   * Gets the settings of the service of this include.
+   *
+   * @return array
+   *   The settings of the service of this include.
+   */
+  public function getServiceSettings();
 
-	/**
-	 * @return array
-	 *   The settings of the service of this include.
-	 */
-	public function getServiceSettings();
+  /**
+   * Gets if this include applies to the entire site rather than specific nodes.
+   *
+   * @return bool
+   *   TRUE if this include applies to the entire site rather than specific
+   *   nodes, FALSE if not.
+   */
+  public function isSitewide();
 
-	/**
-	 * @return boolean
-	 *   TRUE if this include applies to the entire site rather than specific nodes, FALSE if not.
-	 */
-	public function isSitewide();
+  /**
+   * Gets if this include can be added or removed by content authors.
+   *
+   * @return bool
+   *   TRUE if this include can be added or removed by content authors, FALSE
+   *   if not.
+   */
+  public function isContentEditingEnabled();
 
-	/**
-	 * @return boolean
-	 *   TRUE if this include can be added or removed by content authors, FALSE if not.
-	 */
-	public function isContentEditingEnabled();
+  /**
+   * Gets the ids for nodes that have been explicitly included.
+   *
+   * @return string[]
+   *   The ids for nodes that have been explicitly included in the "Content"
+   *   field.
+   */
+  public function getNodeIds();
 
-	/**
-	 * @return string[]
-	 *   The ids for nodes that have been explicitly included in the "Content" field.
-	 */
-	public function getNodeIds();
+  /**
+   * Gets the nodes that this include applies to.
+   *
+   * @return \Drupal\node\NodeInterface[]
+   *   The nodes that this include applies to.
+   */
+  public function getNodes();
 
-	/**
-	 * @return \Drupal\node\NodeInterface[]
-	 *   All the nodes that this include applies to.
-	 */
-	public function getNodes();
 }

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -1,222 +1,236 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\AppearanceForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\ThemeHandlerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Theme\ThemeManagerInterface;
+use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
 use Drupal\system\Form\ThemeSettingsForm;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Extension\ThemeHandlerInterface;
-use Drupal\Core\Theme\ThemeManagerInterface;
-use Drupal\Core\File\FileSystemInterface;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\file\FileInterface;
-use Drupal\file\Entity\File;
 
+/**
+ * The form for the "Appearance" tab in CU Boulder site settings.
+ */
 class AppearanceForm extends ThemeSettingsForm {
 
-	/**
-	 * The current user.
-	 *
-	 * @var \Drupal\Core\Session\AccountInterface
-	 */
-	protected $user;
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
 
-	/**
-	 * The user site configuration service defined in this module.
-	 *
-	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
-	 */
-	protected $service;
+  /**
+   * The site configuration service defined in this module.
+   *
+   * @var \Drupal\ucb_site_configuration\SiteConfiguration
+   */
+  protected $service;
 
-	/**
-	 * Constructs an AppearanceForm object.
-	 *
-	 * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-	 *   The factory for configuration objects.
-	 * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-	 *   The module handler instance to use.
-	 * @param \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler
-	 *   The theme handler.
-	 * @param \Symfony\Component\Mime\MimeTypeGuesserInterface $mime_type_guesser
-	 *   The MIME type guesser instance to use.
-	 * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
-	 *   The theme manager.
-	 * @param \Drupal\Core\File\FileSystemInterface $file_system
-	 *   The file system.
-	 * @param \Drupal\Core\Session\AccountInterface $user
-	 *   The current user.
-	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
-	 *   The service defined in this module.
-	 */
-	public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler, MimeTypeGuesserInterface $mime_type_guesser, ThemeManagerInterface $theme_manager, FileSystemInterface $file_system, AccountInterface $user, SiteConfiguration $service) {
-		parent::__construct($config_factory, $module_handler, $theme_handler, $mime_type_guesser, $theme_manager, $file_system);
-		$this->user = $user;
-		$this->service = $service;
-	}
+  /**
+   * Constructs an AppearanceForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler instance to use.
+   * @param \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler
+   *   The theme handler.
+   * @param \Symfony\Component\Mime\MimeTypeGuesserInterface $mime_type_guesser
+   *   The MIME type guesser instance to use.
+   * @param \Drupal\Core\Theme\ThemeManagerInterface $theme_manager
+   *   The theme manager.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+   *   The site configuration service defined in this module.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, ThemeHandlerInterface $theme_handler, MimeTypeGuesserInterface $mime_type_guesser, ThemeManagerInterface $theme_manager, FileSystemInterface $file_system, AccountInterface $user, SiteConfiguration $service) {
+    parent::__construct($config_factory, $module_handler, $theme_handler, $mime_type_guesser, $theme_manager, $file_system);
+    $this->user = $user;
+    $this->service = $service;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-	 *   The container that allows getting any needed services.
-	 *
-	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
-	 */
-	public static function create(ContainerInterface $container) {
-		return new static(
-			$container->get('config.factory'),
-			$container->get('module_handler'),
-			$container->get('theme_handler'),
-			$container->get('file.mime_type.guesser'),
-			$container->get('theme.manager'),
-			$container->get('file_system'),
-			$container->get('current_user'),
-			$container->get('ucb_site_configuration')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container that allows getting any needed services.
+   *
+   * @link https://www.drupal.org/node/2133171 For more on dependency injection
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler'),
+      $container->get('theme_handler'),
+      $container->get('file.mime_type.guesser'),
+      $container->get('theme.manager'),
+      $container->get('file_system'),
+      $container->get('current_user'),
+      $container->get('ucb_site_configuration')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getFormId() {
-		return 'ucb_site_configuration_appearance_form';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ucb_site_configuration_appearance_form';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function buildForm(array $form, FormStateInterface $form_state, $theme = '') {
-		$theme = $this->service->getThemeName();
-		$form = parent::buildForm($form, $form_state, $theme);
-		if ($this->user->hasPermission('edit ucb site advanced')) {
-			$advanced = [];
-			$advanced['custom_logo'] = [
-				'#type' => 'container'
-			];
-			$advanced['custom_logo']['ucb_use_custom_logo'] = [
-				'#type' => 'checkbox',
-				'#title' => $this->t('Use a custom logo image'),
-				'#default_value' => theme_get_setting('ucb_use_custom_logo', $theme),
-				'#tree' => FALSE
-			];
-			$advanced['custom_logo']['settings'] = [
-				'#type' => 'container',
-				'#states' => [
-					'visible' => [
-						'input[name="ucb_use_custom_logo"]' => ['checked' => TRUE]
-					]
-				]
-			];
-			$advanced['custom_logo']['settings']['ucb_custom_logo_scale'] = [
-				'#markup' => $this->t('For a custom logo, use an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72).')
-			];
-			$advanced['custom_logo']['settings']['dark'] = [
-				'#type' => 'details',
-				'#title' => $this->t('Custom logo – White text on dark header'),
-				'#description' => $this->t('Provide a logo to use with a dark header. Text in the logo should be legible on dark backgrounds.'),
-				'#open' => TRUE
-			];
-			$advanced['custom_logo']['settings']['light'] = [
-				'#type' => 'details',
-				'#title' => $this->t('Custom logo – Black text on light header'),
-				'#description' => $this->t('Provide a logo to use with a light header. Text in the logo should be legible on light backgrounds.'),
-				'#open' => TRUE
-			];
-			$advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_path'] = [
-				'#type' => 'textfield',
-				'#title' => $this->t('Path to a custom logo'),
-				'#default_value' => theme_get_setting('ucb_custom_logo_dark_path', $theme)
-			];
-			$advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_upload'] = [
-				'#type' => 'managed_file',
-				'#title' => $this->t('Upload a custom logo'),
-				'#description' => $this->t('You may upload a custom logo image to use here (files larger than 2 MB won\'t be accepted). The path will be set to the uploaded file automatically when the form is submitted.'),
-				'#multiple' => FALSE,
-				'#upload_location' => 'public://custom_logo/',
-				'#upload_validators' => [
-					'file_validate_is_image' => [],
-					'file_validate_size' => [2097152] // 2 * 1024 * 1024
-				]
-			];
-			$advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_path'] = [
-				'#type' => 'textfield',
-				'#title' => $this->t('Path to a custom logo'),
-				'#default_value' => theme_get_setting('ucb_custom_logo_light_path', $theme)
-			];
-			$advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_upload'] = [
-				'#type' => 'managed_file',
-				'#title' => $this->t('Upload a custom logo'),
-				'#description' => $this->t('You may upload a custom logo image to use here (files larger than 2 MB won\'t be accepted). The path will be set to the uploaded file automatically when the form is submitted.'),
-				'#multiple' => FALSE,
-				'#upload_location' => 'public://custom_logo/',
-				'#upload_validators' => [
-					'file_validate_is_image' => [],
-					'file_validate_size' => [2097152] // 2 * 1024 * 1024
-				]
-			];
-			$form['advanced'] = array_merge($advanced, $form['advanced']);
-		}
-		unset($form['theme_settings'], $form['logo'], $form['favicon']); // Removes some defaults that are normally visible at the top of the theme settings
-		return $form;
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $theme = '') {
+    $theme = $this->service->getThemeName();
+    $form = parent::buildForm($form, $form_state, $theme);
+    if ($this->user->hasPermission('edit ucb site advanced')) {
+      $advanced = [];
+      $advanced['custom_logo'] = [
+        '#type' => 'container',
+      ];
+      $advanced['custom_logo']['ucb_use_custom_logo'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Use a custom logo image'),
+        '#default_value' => theme_get_setting('ucb_use_custom_logo', $theme),
+        '#tree' => FALSE,
+      ];
+      $advanced['custom_logo']['settings'] = [
+        '#type' => 'container',
+        '#states' => [
+          'visible' => [
+            'input[name="ucb_use_custom_logo"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+      $advanced['custom_logo']['settings']['ucb_custom_logo_scale'] = [
+        '#markup' => $this->t('For a custom logo, use an image that is <em>exactly twice</em> the normal size of the logo (meaning for a logo meant to display at 200x36, the image you will upload is 400x72).'),
+      ];
+      $advanced['custom_logo']['settings']['dark'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Custom logo – White text on dark header'),
+        '#description' => $this->t('Provide a logo to use with a dark header. Text in the logo should be legible on dark backgrounds.'),
+        '#open' => TRUE,
+      ];
+      $advanced['custom_logo']['settings']['light'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Custom logo – Black text on light header'),
+        '#description' => $this->t('Provide a logo to use with a light header. Text in the logo should be legible on light backgrounds.'),
+        '#open' => TRUE,
+      ];
+      $advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_path'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Path to a custom logo'),
+        '#default_value' => theme_get_setting('ucb_custom_logo_dark_path', $theme),
+      ];
+      $advanced['custom_logo']['settings']['dark']['ucb_custom_logo_dark_upload'] = [
+        '#type' => 'managed_file',
+        '#title' => $this->t('Upload a custom logo'),
+        '#description' => $this->t("You may upload a custom logo image to use here (files larger than 2 MB won't be accepted). The path will be set to the uploaded file automatically when the form is submitted."),
+        '#multiple' => FALSE,
+        '#upload_location' => 'public://custom_logo/',
+        '#upload_validators' => [
+          'file_validate_is_image' => [],
+          // 2 * 1024 * 1024 = 2097152
+          'file_validate_size' => [2097152],
+        ],
+      ];
+      $advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_path'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Path to a custom logo'),
+        '#default_value' => theme_get_setting('ucb_custom_logo_light_path', $theme),
+      ];
+      $advanced['custom_logo']['settings']['light']['ucb_custom_logo_light_upload'] = [
+        '#type' => 'managed_file',
+        '#title' => $this->t('Upload a custom logo'),
+        '#description' => $this->t("You may upload a custom logo image to use here (files larger than 2 MB won't be accepted). The path will be set to the uploaded file automatically when the form is submitted."),
+        '#multiple' => FALSE,
+        '#upload_location' => 'public://custom_logo/',
+        '#upload_validators' => [
+          'file_validate_is_image' => [],
+          // 2 * 1024 * 1024 = 2097152
+          'file_validate_size' => [2097152],
+        ],
+      ];
+      $form['advanced'] = array_merge($advanced, $form['advanced']);
+    }
+    // Removes some defaults that are normally visible at the top of the theme
+    // settings.
+    unset($form['theme_settings'], $form['logo'], $form['favicon']);
+    return $form;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function validateForm(array &$form, FormStateInterface $form_state) {
-		parent::validateForm($form, $form_state);
-		if ($form_state->getValue('ucb_use_custom_logo')) { // Validate the custom logo path fields, setting path equal to an uploaded file path (if applicable)
-			$fidsDark = $form_state->getValue('ucb_custom_logo_dark_upload');
-			if ($fidsDark && isset($fidsDark[0]) && ($file = File::load($fidsDark[0])))
-				$form_state->setValue('ucb_custom_logo_dark_path', $file->getFileUri());
-			$fidsLight = $form_state->getValue('ucb_custom_logo_light_upload');
-			if ($fidsLight && isset($fidsLight[0]) && ($file = File::load($fidsLight[0])))
-				$form_state->setValue('ucb_custom_logo_light_path', $file->getFileUri());
-			$pathDark = $this->validatePath($form_state->getValue('ucb_custom_logo_dark_path'));
-			if ($pathDark)
-				$form_state->setValue('ucb_custom_logo_dark_path', $pathDark);
-			else $form_state->setErrorByName('ucb_custom_logo_dark_path', $this->t('The white text on dark header custom logo path is invalid. Please either upload an image or specify a valid file path to use a custom logo.'));
-			$pathLight = $this->validatePath($form_state->getValue('ucb_custom_logo_light_path'));
-			if ($pathLight)
-				$form_state->setValue('ucb_custom_logo_light_path', $pathLight);
-			else $form_state->setErrorByName('ucb_custom_logo_light_path', $this->t('The black text on light header custom logo path is invalid. Please either upload an image or specify a valid file path to use a custom logo.'));
-		}
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    // Validates the custom logo path fields, setting path equal to an uploaded
+    // file path (if applicable).
+    if ($form_state->getValue('ucb_use_custom_logo')) {
+      $fidsDark = $form_state->getValue('ucb_custom_logo_dark_upload');
+      if ($fidsDark && isset($fidsDark[0]) && ($file = File::load($fidsDark[0]))) {
+        $form_state->setValue('ucb_custom_logo_dark_path', $file->getFileUri());
+      }
+      $fidsLight = $form_state->getValue('ucb_custom_logo_light_upload');
+      if ($fidsLight && isset($fidsLight[0]) && ($file = File::load($fidsLight[0]))) {
+        $form_state->setValue('ucb_custom_logo_light_path', $file->getFileUri());
+      }
+      $pathDark = $this->validatePath($form_state->getValue('ucb_custom_logo_dark_path'));
+      if ($pathDark) {
+        $form_state->setValue('ucb_custom_logo_dark_path', $pathDark);
+      }
+      else {
+        $form_state->setErrorByName('ucb_custom_logo_dark_path', $this->t('The white text on dark header custom logo path is invalid. Please either upload an image or specify a valid file path to use a custom logo.'));
+      }
+      $pathLight = $this->validatePath($form_state->getValue('ucb_custom_logo_light_path'));
+      if ($pathLight) {
+        $form_state->setValue('ucb_custom_logo_light_path', $pathLight);
+      }
+      else {
+        $form_state->setErrorByName('ucb_custom_logo_light_path', $this->t('The black text on light header custom logo path is invalid. Please either upload an image or specify a valid file path to use a custom logo.'));
+      }
+    }
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$fidsDark = $form_state->getValue('ucb_custom_logo_dark_upload');
-		if ($fidsDark && isset($fidsDark[0]) && ($file = File::load($fidsDark[0])))
-			$this->makePermanent($file);
-		$fidsLight = $form_state->getValue('ucb_custom_logo_light_upload');
-		if ($fidsLight && isset($fidsLight[0]) && ($file = File::load($fidsLight[0])))
-			$this->makePermanent($file);
-		$form_state->unsetValue('ucb_custom_logo_dark_upload');
-		$form_state->unsetValue('ucb_custom_logo_light_upload');
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $fidsDark = $form_state->getValue('ucb_custom_logo_dark_upload');
+    if ($fidsDark && isset($fidsDark[0]) && ($file = File::load($fidsDark[0]))) {
+      $this->makePermanent($file);
+    }
+    $fidsLight = $form_state->getValue('ucb_custom_logo_light_upload');
+    if ($fidsLight && isset($fidsLight[0]) && ($file = File::load($fidsLight[0]))) {
+      $this->makePermanent($file);
+    }
+    $form_state->unsetValue('ucb_custom_logo_dark_upload');
+    $form_state->unsetValue('ucb_custom_logo_light_upload');
 
-		parent::submitForm($form, $form_state);
-	}
+    parent::submitForm($form, $form_state);
+  }
 
-	/**
-	 * This helper function makes a file permanent.
-	 * 
-	 * @param \Drupal\file\FileInterface
-	 *   A file entity.
-	 */
-	protected function makePermanent(FileInterface $file) {
-		$file->setPermanent();
-		$file->save();
-	}
+  /**
+   * This helper function makes a file permanent.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   A file entity.
+   */
+  protected function makePermanent(FileInterface $file) {
+    $file->setPermanent();
+    $file->save();
+  }
+
 }

--- a/src/Form/ContactInfoForm.php
+++ b/src/Form/ContactInfoForm.php
@@ -1,167 +1,183 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\ContactInfoForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
+/**
+ * The form for the "Contact info" tab in CU Boulder site settings.
+ */
 class ContactInfoForm extends ConfigFormBase {
 
-	/**
-	 * @return string
-	 */
-	public function getFormId() {
-		return 'ucb_site_configuration_contact_info_form';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ucb_site_configuration_contact_info_form';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	protected function getEditableConfigNames() {
-		return ['ucb_site_configuration.contact_info'];
-	}
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['ucb_site_configuration.contact_info'];
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function buildForm(array $form, FormStateInterface $form_state) {
-		$config = $this->config('ucb_site_configuration.contact_info');
-		// Toggle for icons
-		$generalStoredValues = $config->get('general');
-		$emailStoredValues = $config->get('email');
-		$phoneStoredValues = $config->get('phone');
-		if($generalStoredValues)
-			$this->_buildFormSection(sizeof($generalStoredValues), 'Contact information', 'contact information', 'general', 'Label (optional)', 'Value', 'text_format', 255, $generalStoredValues, $form);
-		if($emailStoredValues)
-			$this->_buildFormSection(sizeof($emailStoredValues), 'Email address', 'email address', 'email', 'Label (optional)', 'Value', 'email', 20, $emailStoredValues, $form);
-		if($phoneStoredValues)
-			$this->_buildFormSection(sizeof($phoneStoredValues), 'Phone number', 'phone number', 'phone', 'Label (optional)', 'Value', 'tel', 20, $phoneStoredValues, $form);
-		$form['icons_visible'] = [
-			'#type' => 'checkbox',
-			'#title' => $this->t('Show email and / or phone icons in the site footer'),
-			'#default_value' => $config->get('icons_visible') ?? TRUE
-		];
-		return parent::buildForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('ucb_site_configuration.contact_info');
+    // Toggle for icons.
+    $generalStoredValues = $config->get('general');
+    $emailStoredValues = $config->get('email');
+    $phoneStoredValues = $config->get('phone');
+    if ($generalStoredValues) {
+      $this->buildFormSection(count($generalStoredValues), 'Contact information', 'contact information', 'general', 'Label (optional)', 'Value', 'text_format', 255, $generalStoredValues, $form);
+    }
+    if ($emailStoredValues) {
+      $this->buildFormSection(count($emailStoredValues), 'Email address', 'email address', 'email', 'Label (optional)', 'Value', 'email', 20, $emailStoredValues, $form);
+    }
+    if ($phoneStoredValues) {
+      $this->buildFormSection(count($phoneStoredValues), 'Phone number', 'phone number', 'phone', 'Label (optional)', 'Value', 'tel', 20, $phoneStoredValues, $form);
+    }
+    $form['icons_visible'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show email and / or phone icons in the site footer'),
+      '#default_value' => $config->get('icons_visible') ?? TRUE,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
 
-	private function _buildFormSection($itemCount, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, array &$form) {
-		// Toggle for "Add primary x"
-		$form[$machineName . '_0_visible'] = [
-			'#type' => 'checkbox',
-			'#title' => $this->t('Add primary ' . $verboseNameLower),
-			'#default_value' => $storedValues[0]['visible'] ?? FALSE
-		];
-		// Section "Primary x"
-		$sectionForm = [
-			'#type' => 'details',
-			'#title' => $this->t('Primary ' . $verboseNameLower),
-			'#open' => TRUE,
-			'#states' => [
-				'visible' => [
-					':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE]
-				]
-			]
-		];
-		// Fields for primary item
-		$this->_buildFieldSection(0, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, $sectionForm);
-		// Add secondary items
-		for ($index = 1; $index < $itemCount; $index++) {
-			// Toggle for "Add another x"
-			$sectionForm[$machineName . '_' . $index . '_visible'] = [
-				'#type' => 'checkbox',
-				'#title' => $this->t('Add another ' . $verboseNameLower),
-				'#default_value' => $storedValues[$index]['visible'] ?? FALSE
-			];
-			// Section "[another] x"
-			$subSectionForm = [
-				'#type' => 'details',
-				'#title' => $this->t($verboseName),
-				'#open' => TRUE,
-				'#states' => [
-					'visible' => [
-						':input[name="' . $machineName . '_' . $index . '_visible"]' => ['checked' => TRUE]
-					]
-				]
-			];
-			// Fields for secondary item
-			$this->_buildFieldSection($index, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, $subSectionForm);
-			$sectionForm[$machineName . '_' . $index] = $subSectionForm;
-		}
-		$form[$machineName . '_' . $index] = $sectionForm;
-	}
+  /**
+   * Builds a section for general, email, or phone number.
+   */
+  private function buildFormSection($itemCount, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, array &$form) {
+    // Toggle for "Add primary x".
+    $form[$machineName . '_0_visible'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Add primary ' . $verboseNameLower),
+      '#default_value' => $storedValues[0]['visible'] ?? FALSE,
+    ];
+    // Section "Primary x".
+    $sectionForm = [
+      '#type' => 'details',
+      '#title' => $this->t('Primary ' . $verboseNameLower),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    // Fields for primary item.
+    $this->buildFieldSection(0, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, $sectionForm);
+    // Add secondary items.
+    for ($index = 1; $index < $itemCount; $index++) {
+      // Toggle for "Add another x".
+      $sectionForm[$machineName . '_' . $index . '_visible'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Add another ' . $verboseNameLower),
+        '#default_value' => $storedValues[$index]['visible'] ?? FALSE,
+      ];
+      // Section "[another] x".
+      $subSectionForm = [
+        '#type' => 'details',
+        '#title' => $this->t($verboseName),
+        '#open' => TRUE,
+        '#states' => [
+          'visible' => [
+            ':input[name="' . $machineName . '_' . $index . '_visible"]' => ['checked' => TRUE],
+          ],
+        ],
+      ];
+      // Fields for secondary item.
+      $this->buildFieldSection($index, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, $subSectionForm);
+      $sectionForm[$machineName . '_' . $index] = $subSectionForm;
+    }
+    $form[$machineName . '_' . $index] = $sectionForm;
+  }
 
-	private function _buildFieldSection($index, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, array &$form) {
-		$form[$machineName . '_' . $index . '_label'] = [
-			'#type' => 'textfield',
-			// '#size' => 32,
-			'#title' => $this->t($labelFieldLabel),
-			'#default_value' => $storedValues[$index]['label'] ?? ''
-		];
-		$value = $storedValues[$index]['value'];
-		$fieldName = $machineName . '_' . $index . '_value';
-		$form[$fieldName] = [
-			'#type' => $valueFieldType,
-			// '#size' => $valueFieldSize,
-			'#title' => $this->t($valueFieldLabel),
-			'#default_value' => is_array($value) ? $value['value'] : $value,
-			'#states' => [
-				'required' => [
-					':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE]
-				]
-			]
-		];
-		if ($valueFieldType == 'text_format') {
-			$form[$fieldName]['#format'] = $value['format'] ?? '';
-			$form[$fieldName]['#base_type'] = 'textarea';
-			$form[$fieldName]['#states']['required'] = [];
-		} else if ($index > 0) {
-			$form[$fieldName]['#states']['required'][] = 'and';
-			$form[$fieldName]['#states']['required'][':input[name="' . $machineName . '_' . $index . '_visible"]'] = ['checked' => TRUE];
-		}
-	}
+  /**
+   * Builds a set of fields to go inside a form section.
+   *
+   * A form section for general, email, or phone number will have the ability to
+   * add more than one item, so this is called more than once for a form
+   * section.
+   */
+  private function buildFieldSection($index, $verboseName, $verboseNameLower, $machineName, $labelFieldLabel, $valueFieldLabel, $valueFieldType, $valueFieldSize, $storedValues, array &$form) {
+    $form[$machineName . '_' . $index . '_label'] = [
+      '#type' => 'textfield',
+      // '#size' => 32,
+      '#title' => $this->t($labelFieldLabel),
+      '#default_value' => $storedValues[$index]['label'] ?? '',
+    ];
+    $value = $storedValues[$index]['value'];
+    $fieldName = $machineName . '_' . $index . '_value';
+    $form[$fieldName] = [
+      '#type' => $valueFieldType,
+      // '#size' => $valueFieldSize,
+      '#title' => $this->t($valueFieldLabel),
+      '#default_value' => is_array($value) ? $value['value'] : $value,
+      '#states' => [
+        'required' => [
+          ':input[name="' . $machineName . '_0_visible"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    if ($valueFieldType == 'text_format') {
+      $form[$fieldName]['#format'] = $value['format'] ?? '';
+      $form[$fieldName]['#base_type'] = 'textarea';
+      $form[$fieldName]['#states']['required'] = [];
+    }
+    elseif ($index > 0) {
+      $form[$fieldName]['#states']['required'][] = 'and';
+      $form[$fieldName]['#states']['required'][':input[name="' . $machineName . '_' . $index . '_visible"]'] = ['checked' => TRUE];
+    }
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$formValues = $form_state->getValues();
-		$config = $this->config('ucb_site_configuration.contact_info');
-		$fieldNames = ['visible', 'label', 'value'];
-		$generalStoredValues = $config->get('general');
-		$emailStoredValues = $config->get('email');
-		$phoneStoredValues = $config->get('phone');
-		$this->_saveFormSection($formValues, $config, 'general', $fieldNames, sizeof($generalStoredValues));
-		$this->_saveFormSection($formValues, $config, 'email', $fieldNames, sizeof($emailStoredValues));
-		$this->_saveFormSection($formValues, $config, 'phone', $fieldNames, sizeof($phoneStoredValues));
-		// Set icons setting and save configuration
-		$config
-			->set('icons_visible', $formValues['icons_visible'])
-			->save();
-		// Clear the cache so the new information will display in the site footer right away.
-		// Not the recommended way to do this, but I tried cache tags and that did not work.
-		\Drupal::service('cache.render')->invalidateAll();
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $formValues = $form_state->getValues();
+    $config = $this->config('ucb_site_configuration.contact_info');
+    $fieldNames = ['visible', 'label', 'value'];
+    $generalStoredValues = $config->get('general');
+    $emailStoredValues = $config->get('email');
+    $phoneStoredValues = $config->get('phone');
+    $this->saveFormSection($formValues, $config, 'general', $fieldNames, count($generalStoredValues));
+    $this->saveFormSection($formValues, $config, 'email', $fieldNames, count($emailStoredValues));
+    $this->saveFormSection($formValues, $config, 'phone', $fieldNames, count($phoneStoredValues));
+    // Set icons setting and save configuration.
+    $config
+      ->set('icons_visible', $formValues['icons_visible'])
+      ->save();
+    // Clear the cache so the new information will display in the site footer right away.
+    // Not the recommended way to do this, but I tried cache tags and that did not work.
+    \Drupal::service('cache.render')->invalidateAll();
+  }
 
-	private static function _saveFormSection($formValues, $config, $sectionName, $fieldNames, $itemCount) {
-		// Gather all primary / secondary fields from the form into one array.
-		$values = [];
-		for ($index = 0; $index < $itemCount; $index++) {
-			$fieldNameValueDict = [];
-			foreach ($fieldNames as $fieldName) {
-				$fieldNameValueDict[$fieldName] = $formValues[$sectionName . '_' . $index . '_' . $fieldName];
-			}
-			$values[] = $fieldNameValueDict;
-		}
-		// The form design necessitates hiding all items if the primary one is not shown.
-		$categoryVisible = $values[0]['visible'];
-		// Set the configuration.
-		$config
-			->set($sectionName . '_visible', $categoryVisible)
-			->set($sectionName, $values);
-	}
+  /**
+   * Saves the values of a section for general, email, or phone number.
+   */
+  private static function saveFormSection($formValues, $config, $sectionName, $fieldNames, $itemCount) {
+    // Gather all primary / secondary fields from the form into one array.
+    $values = [];
+    for ($index = 0; $index < $itemCount; $index++) {
+      $fieldNameValueDict = [];
+      foreach ($fieldNames as $fieldName) {
+        $fieldNameValueDict[$fieldName] = $formValues[$sectionName . '_' . $index . '_' . $fieldName];
+      }
+      $values[] = $fieldNameValueDict;
+    }
+    // The form design necessitates hiding all items if the primary one is not shown.
+    $categoryVisible = $values[0]['visible'];
+    // Set the configuration.
+    $config
+      ->set($sectionName . '_visible', $categoryVisible)
+      ->set($sectionName, $values);
+  }
+
 }

--- a/src/Form/ExternalServiceIncludeEntityDeleteForm.php
+++ b/src/Form/ExternalServiceIncludeEntityDeleteForm.php
@@ -1,48 +1,44 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityDeleteForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Entity\EntityConfirmFormBase;
-use Drupal\Core\Url;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
- * Builds the form to delete an ExternalServiceInclude entity.
+ * The form to delete a third-party service.
  */
-
 class ExternalServiceIncludeEntityDeleteForm extends EntityConfirmFormBase {
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getQuestion() {
-		return $this->t('Are you sure you want to delete the third-party service %label?', ['%label' => $this->entity->label()]);
-	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getCancelUrl() {
-		return Url::fromRoute('entity.ucb_external_service_include.collection');
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete the third-party service %label?', ['%label' => $this->entity->label()]);
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getConfirmText() {
-		return $this->t('Delete');
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return Url::fromRoute('entity.ucb_external_service_include.collection');
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$this->entity->delete();
-		$this->messenger()->addMessage($this->t('Third-party service %label has been deleted.', ['%label' => $this->entity->label()]));
-		$form_state->setRedirectUrl($this->getCancelUrl());
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->delete();
+    $this->messenger()->addMessage($this->t('Third-party service %label has been deleted.', ['%label' => $this->entity->label()]));
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
 }

--- a/src/Form/ExternalServiceIncludeEntityForm.php
+++ b/src/Form/ExternalServiceIncludeEntityForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\ExternalServiceIncludeEntityForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Entity\EntityForm;
@@ -14,273 +9,288 @@ use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Builds the form to add or edit an ExternalServiceInclude entity.
+ * The form to add or edit a third-party service.
  */
-
 class ExternalServiceIncludeEntityForm extends EntityForm {
 
-	/**
-	 * The user site configuration service defined in this module.
-	 *
-	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
-	 */
-	protected $service;
+  /**
+   * The site configuration service defined in this module.
+   *
+   * @var \Drupal\ucb_site_configuration\SiteConfiguration
+   */
+  protected $service;
 
-	/**
-	 * Constructs an ExternalServiceIncludeEntityForm object.
-	 * 
-	 * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   	 *   The entity type manager.
-	 *
-	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
-	 *   The service defined in this module.
-	 */
-	public function __construct(EntityTypeManagerInterface $entityTypeManager, SiteConfiguration $service) {
-		$this->entityTypeManager = $entityTypeManager;
-		$this->service = $service;
-	}
+  /**
+   * Constructs an ExternalServiceIncludeEntityForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+   *   The site configuration service defined in this module.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, SiteConfiguration $service) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->service = $service;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-	 *   The container that allows getting any needed services.
-	 *
-	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
-	 */
-	public static function create(ContainerInterface $container) {
-		return new static(
-			$container->get('entity_type.manager'),
-			$container->get('ucb_site_configuration')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container that allows getting any needed services.
+   *
+   * @link https://www.drupal.org/node/2133171 For more on dependency injection
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+    $container->get('entity_type.manager'),
+    $container->get('ucb_site_configuration')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getFormId() {
-		return 'ucb_external_service_include_entity_form';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ucb_external_service_include_entity_form';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function form(array $form, FormStateInterface $form_state) {
-		/** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface */
-		$entity = $this->entity;
-		$allowedExternalServiceOptions = $this->service->getExternalServicesOptions();
-		$exists = $this->exists($entity->id());
-		$form['service_name'] = [
-			'#type'  => 'radios',
-			'#title' => $this->t('Service'),
-			'#options' => $allowedExternalServiceOptions,
-			'#default_value' => $entity->getServiceName(),
-			'#required' => TRUE
-		];
-		$externalServicesConfig = $this->service->getConfiguration()->get('external_services');
-		foreach ($allowedExternalServiceOptions as $externalServiceName => $externalServiceLabel) {
-			$serviceSettingsForm = [
-				'#type' => 'details',
-				'#title' => $this->t('%service configuration', ['%service' => $externalServiceLabel]),
-				'#open' => !$exists || $externalServiceName != $entity->getServiceName(),
-				'#states' => [
-					'visible' => [
-						':input[name="service_name"]' => ['value' => $externalServiceName]
-					]
-				]
-			];
-			$this->buildExternalServiceSiteSettingsForm($serviceSettingsForm, $externalServiceName, $externalServicesConfig[$externalServiceName], $entity->getServiceSettings(), $form_state);
-			$form['service_' . $externalServiceName . '_settings'] = $serviceSettingsForm;
-		}
-		$form['label'] = [
-			'#type' => 'textfield',
-			'#title' => t('Label'),
-			'#maxlength' => 255,
-			'#default_value' => $entity->label(),
-			'#required' => TRUE
-		];
-		$form['id'] = [
-			'#type' => 'machine_name',
-			'#default_value' => $entity->id(),
-			'#machine_name' => [
-			  'exists' => [$this, 'exists'],
-			],
-			'#disabled' => !$entity->isNew()
-		];
-		$form['sitewide'] = [
-			'#type'  => 'radios',
-			'#title' => t('Include this service on'),
-			'#options' => [
-				$this->t('Specific content'),
-				$this->t('All content on this site')
-			],
-			'#default_value' => $entity->isSitewide() ? 1 : 0,
-			'#required' => TRUE
-		];
-		$form['content_options_container'] = [
-			'#type' => 'container',
-			'node_entity_autocomplete' => [
-				'#type' => 'entity_autocomplete',
-				'#target_type' => 'node',
-				'#title' => $this->t('Content'),
-				'#description' => $this->t('Specify content to include this service on. Multiple entries may be seperated by commas.'),
-				'#default_value' => $entity->getNodes(),
-				'#tags' => TRUE,
-			],
-			'content_editing_enabled' => [
-				'#type' => 'checkbox',
-				'#target_type' => 'node',
-				'#title' => $this->t('Allow content authors to add or remove this service for content they can edit'),
-				'#description' => $this->t('If enabled, all users will be able to add or remove this service for content they can edit, including when creating new content. A user with permission to administer third-party services will always be able to add or remove this service, regardless if enabled.'),
-				'#default_value' => $entity->isContentEditingEnabled(),
-				'#tags' => TRUE,
-				'#states' => [
-					'visible' => [':input[name="sitewide"]' => ['value' => 0]]
-				]
-			],
-			'#states' => [
-				'visible' => [':input[name="sitewide"]' => ['value' => 0]]
-			]
-		];
-		return $form + parent::form($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface */
+    $entity = $this->entity;
+    $allowedExternalServiceOptions = $this->service->getExternalServicesOptions();
+    $exists = $this->exists($entity->id());
+    $form['service_name'] = [
+      '#type'  => 'radios',
+      '#title' => $this->t('Service'),
+      '#options' => $allowedExternalServiceOptions,
+      '#default_value' => $entity->getServiceName(),
+      '#required' => TRUE,
+    ];
+    $externalServicesConfig = $this->service->getConfiguration()->get('external_services');
+    foreach ($allowedExternalServiceOptions as $externalServiceName => $externalServiceLabel) {
+      $serviceSettingsForm = [
+        '#type' => 'details',
+        '#title' => $this->t('%service configuration', ['%service' => $externalServiceLabel]),
+        '#open' => !$exists || $externalServiceName != $entity->getServiceName(),
+        '#states' => [
+          'visible' => [
+            ':input[name="service_name"]' => ['value' => $externalServiceName],
+          ],
+        ],
+      ];
+      $this->buildExternalServiceSiteSettingsForm($serviceSettingsForm, $externalServiceName, $externalServicesConfig[$externalServiceName], $entity->getServiceSettings(), $form_state);
+      $form['service_' . $externalServiceName . '_settings'] = $serviceSettingsForm;
+    }
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#maxlength' => 255,
+      '#default_value' => $entity->label(),
+      '#required' => TRUE,
+    ];
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $entity->id(),
+      '#machine_name' => [
+        'exists' => [$this, 'exists'],
+      ],
+      '#disabled' => !$entity->isNew(),
+    ];
+    $form['sitewide'] = [
+      '#type'  => 'radios',
+      '#title' => $this->t('Include this service on'),
+      '#options' => [
+        $this->t('Specific content'),
+        $this->t('All content on this site'),
+      ],
+      '#default_value' => $entity->isSitewide() ? 1 : 0,
+      '#required' => TRUE,
+    ];
+    $form['content_options_container'] = [
+      '#type' => 'container',
+      'node_entity_autocomplete' => [
+        '#type' => 'entity_autocomplete',
+        '#target_type' => 'node',
+        '#title' => $this->t('Content'),
+        '#description' => $this->t('Specify content to include this service on. Multiple entries may be seperated by commas.'),
+        '#default_value' => $entity->getNodes(),
+        '#tags' => TRUE,
+      ],
+      'content_editing_enabled' => [
+        '#type' => 'checkbox',
+        '#target_type' => 'node',
+        '#title' => $this->t('Allow content authors to add or remove this service for content they can edit'),
+        '#description' => $this->t('If enabled, all users will be able to add or remove this service for content they can edit, including when creating new content. A user with permission to administer third-party services will always be able to add or remove this service, regardless if enabled.'),
+        '#default_value' => $entity->isContentEditingEnabled(),
+        '#tags' => TRUE,
+        '#states' => [
+          'visible' => [':input[name="sitewide"]' => ['value' => 0]],
+        ],
+      ],
+      '#states' => [
+        'visible' => [':input[name="sitewide"]' => ['value' => 0]],
+      ],
+    ];
+    return $form + parent::form($form, $form_state);
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function validateForm(array &$form, FormStateInterface $form_state) { // TODO: Finish validation function
-		$externalServiceName = $form_state->getValue('service_name');
-		switch ($externalServiceName) {
-			case 'mainstay':
-				$licenseIdFieldName = $externalServiceName . '__bot_token';
-				$licenseId = $form_state->getValue($licenseIdFieldName);
-				if(!preg_match('/^[a-z0-9]+$/', $licenseId))
-					$form_state->setErrorByName($licenseIdFieldName, $this->t('A valid bot token is a mix of lowercase letters and numbers.'));
-			break;
-			case 'livechat':
-				$licenseIdFieldName = $externalServiceName . '__license_id';
-				$licenseId = $form_state->getValue($licenseIdFieldName);
-				if(!preg_match('/^[0-9]+$/', $licenseId))
-					$form_state->setErrorByName($licenseIdFieldName, $this->t('A valid license ID contains only numbers.'));
-			break;
-			case 'statuspage':
-				$pageIdFieldName = $externalServiceName . '__page_id';
-				$pageId = $form_state->getValue($pageIdFieldName);
-				if(strlen($pageId) != 12 || !preg_match('/^[a-z0-9]+$/', $pageId)) // preg_match validation on page id is important and stops potential script injection
-					$form_state->setErrorByName($pageIdFieldName, $this->t('A valid page ID is 12 characters long and a mix of lowercase letters and numbers.'));
-			break;
-			default:
-		}
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $externalServiceName = $form_state->getValue('service_name');
+    switch ($externalServiceName) {
+      case 'mainstay':
+        $licenseIdFieldName = $externalServiceName . '__bot_token';
+        $licenseId = $form_state->getValue($licenseIdFieldName);
+        if (!preg_match('/^[a-z0-9]+$/', $licenseId)) {
+          $form_state->setErrorByName($licenseIdFieldName, $this->t('A valid bot token is a mix of lowercase letters and numbers.'));
+        }
+        break;
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function save(array $form, FormStateInterface $form_state) {
-		/** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface */
-		$entity = $this->entity;
-		// Set `service_settings` for the selected service
-		$externalServiceName = $entity->getServiceName();
-		$externalServiceConfig = $this->service->getConfiguration()->get('external_services')[$externalServiceName];
-		$externalServiceSettings = [];
-		foreach ($externalServiceConfig['settings'] as $settingName)
-			$externalServiceSettings[$settingName] = $form_state->getValue($externalServiceName . '__' . $settingName) ?? '';
-		$entity->set('service_settings', $externalServiceSettings);
-		// Set `nodes` from the special content field
-		$entity->set('nodes', array_map(function($node){ return intval($node['target_id']); }, $form_state->getValue('node_entity_autocomplete') ?? []));
-		// Save the entity
-		$status = $entity->save();
-		if ($status === SAVED_NEW) {
-			$this->messenger()->addMessage($this->t('The %label third-party service created.', ['%label' => $entity->label()]));
-		} else {
-			$this->messenger()->addMessage($this->t('The %label third-party service updated.', ['%label' => $entity->label()]));
-		}
-		$form_state->setRedirect('entity.ucb_external_service_include.collection');
-	}
+      case 'livechat':
+        $licenseIdFieldName = $externalServiceName . '__license_id';
+        $licenseId = $form_state->getValue($licenseIdFieldName);
+        if (!preg_match('/^[0-9]+$/', $licenseId)) {
+          $form_state->setErrorByName($licenseIdFieldName, $this->t('A valid license ID contains only numbers.'));
+        }
+        break;
 
-	/**
-	 * Helper function to check whether the ExternalServiceInclude configuration entity exists.
-	 * 
-	 * @see https://www.drupal.org/node/1809494
-	 */
-	public function exists($id) {
-		$entity = $this->entityTypeManager->getStorage('ucb_external_service_include')->getQuery()
-			->condition('id', $id)
-			->execute();
-		return (bool) $entity;
-	}
+      case 'statuspage':
+        $pageIdFieldName = $externalServiceName . '__page_id';
+        $pageId = $form_state->getValue($pageIdFieldName);
+        // preg_match validation on page id is important and stops potential
+        // script injection.
+        if (strlen($pageId) != 12 || !preg_match('/^[a-z0-9]+$/', $pageId)) {
+          $form_state->setErrorByName($pageIdFieldName, $this->t('A valid page ID is 12 characters long and a mix of lowercase letters and numbers.'));
+        }
+        break;
 
-	/**
-	 * Builds the inner settings form for an external service on the "Third-party services" administration page.
-	 * 
-	 * @param array &$form
-	 *   The form build array.
-	 * @param string $externalServiceName
-	 *   The machine name of the external srvice.
-	 * @param array $externalServiceConfig
-	 *   The fixed configuration of the external service.
-	 * @param array $externalServiceSettings
-	 *   The editable settings of the external service.
-	 * @param FormStateInterface $form_state
-	 *   The current state of the form.
-	 */
-	private function buildExternalServiceSiteSettingsForm(array &$form, $externalServiceName, $externalServiceConfig, $externalServiceSettings, FormStateInterface $form_state) {
-		switch ($externalServiceName) {
-			case 'mainstay':
-				$form[$externalServiceName . '__bot_token'] = [
-					'#type' => 'textfield',
-					'#size' => 24,
-					'#maxlength' => 24,
-					'#title' => $this->t('Bot token'),
-					'#default_value' => $externalServiceSettings['bot_token'] ?? '',
-					'#states' => [
-						'required' => [
-							':input[name="service_name"]' => ['value' => $externalServiceName]
-						]
-					]
-				];
-				$form[$externalServiceName . '__college_id'] = [
-					'#type' => 'textfield',
-					'#size' => 64,
-					'#maxlength' => 64,
-					'#title' => $this->t('College ID'),
-					'#default_value' => $externalServiceSettings['college_id'] ?? '',
-					'#states' => [
-						'required' => [
-							':input[name="service_name"]' => ['value' => $externalServiceName]
-						]
-					]
-				];
-			break;
-			case 'livechat':
-				$form[$externalServiceName . '__license_id'] = [
-					'#type' => 'textfield',
-					'#size' => 12,
-					'#maxlength' => 12,
-					'#title' => $this->t('License ID'),
-					'#default_value' => $externalServiceSettings['license_id'] ?? '',
-					'#states' => [
-						'required' => [
-							':input[name="service_name"]' => ['value' => $externalServiceName]
-						]
-					]
-				];
-			break;
-			case 'statuspage':
-				$form[$externalServiceName . '__page_id'] = [ // TODO: validate page id as a letter/number string, exactly 12 characters
-					'#type' => 'textfield',
-					'#size' => 12,
-					'#maxlength' => 12,
-					'#title' => $this->t('Page ID'),
-					'#default_value' => $externalServiceSettings['page_id'] ?? '',
-					'#states' => [
-						'required' => [
-							':input[name="service_name"]' => ['value' => $externalServiceName]
-						]
-					]
-				];
-			break;
-			default:
-		}
-	}
+      default:
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface */
+    $entity = $this->entity;
+    // Set `service_settings` for the selected service.
+    $externalServiceName = $entity->getServiceName();
+    $externalServiceConfig = $this->service->getConfiguration()->get('external_services')[$externalServiceName];
+    $externalServiceSettings = [];
+    foreach ($externalServiceConfig['settings'] as $settingName) {
+      $externalServiceSettings[$settingName] = $form_state->getValue($externalServiceName . '__' . $settingName) ?? '';
+    }
+    $entity->set('service_settings', $externalServiceSettings);
+    // Set `nodes` from the special content field.
+    $entity->set('nodes', array_map(function ($node) {
+      return intval($node['target_id']);
+    }, $form_state->getValue('node_entity_autocomplete') ?? []));
+    // Save the entity.
+    $status = $entity->save();
+    if ($status === SAVED_NEW) {
+      $this->messenger()->addMessage($this->t('The %label third-party service created.', ['%label' => $entity->label()]));
+    }
+    else {
+      $this->messenger()->addMessage($this->t('The %label third-party service updated.', ['%label' => $entity->label()]));
+    }
+    $form_state->setRedirect('entity.ucb_external_service_include.collection');
+  }
+
+  /**
+   * Checks whether the ExternalServiceInclude configuration entity exists.
+   *
+   * @see https://www.drupal.org/node/1809494
+   */
+  public function exists($id) {
+    $entity = $this->entityTypeManager->getStorage('ucb_external_service_include')->getQuery()
+      ->condition('id', $id)
+      ->execute();
+    return (bool) $entity;
+  }
+
+  /**
+   * Builds the inner settings form for an external service.
+   *
+   * @param array &$form
+   *   The form build array.
+   * @param string $externalServiceName
+   *   The machine name of the external srvice.
+   * @param array $externalServiceConfig
+   *   The fixed configuration of the external service.
+   * @param array $externalServiceSettings
+   *   The editable settings of the external service.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  private function buildExternalServiceSiteSettingsForm(array &$form, $externalServiceName, $externalServiceConfig, $externalServiceSettings, FormStateInterface $form_state) {
+    switch ($externalServiceName) {
+      case 'mainstay':
+        $form[$externalServiceName . '__bot_token'] = [
+          '#type' => 'textfield',
+          '#size' => 24,
+          '#maxlength' => 24,
+          '#title' => $this->t('Bot token'),
+          '#default_value' => $externalServiceSettings['bot_token'] ?? '',
+          '#states' => [
+            'required' => [
+              ':input[name="service_name"]' => ['value' => $externalServiceName],
+            ],
+          ],
+        ];
+        $form[$externalServiceName . '__college_id'] = [
+          '#type' => 'textfield',
+          '#size' => 64,
+          '#maxlength' => 64,
+          '#title' => $this->t('College ID'),
+          '#default_value' => $externalServiceSettings['college_id'] ?? '',
+          '#states' => [
+            'required' => [
+              ':input[name="service_name"]' => ['value' => $externalServiceName],
+            ],
+          ],
+        ];
+        break;
+
+      case 'livechat':
+        $form[$externalServiceName . '__license_id'] = [
+          '#type' => 'textfield',
+          '#size' => 12,
+          '#maxlength' => 12,
+          '#title' => $this->t('License ID'),
+          '#default_value' => $externalServiceSettings['license_id'] ?? '',
+          '#states' => [
+            'required' => [
+              ':input[name="service_name"]' => ['value' => $externalServiceName],
+            ],
+          ],
+        ];
+        break;
+
+      case 'statuspage':
+        // @todo validate page id as a letter/number string, exactly 12 characters
+        $form[$externalServiceName . '__page_id'] = [
+          '#type' => 'textfield',
+          '#size' => 12,
+          '#maxlength' => 12,
+          '#title' => $this->t('Page ID'),
+          '#default_value' => $externalServiceSettings['page_id'] ?? '',
+          '#states' => [
+            'required' => [
+              ':input[name="service_name"]' => ['value' => $externalServiceName],
+            ],
+          ],
+        ];
+        break;
+
+      default:
+    }
+  }
+
 }

--- a/src/Form/GeneralForm.php
+++ b/src/Form/GeneralForm.php
@@ -5,13 +5,49 @@ namespace Drupal\ucb_site_configuration\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\Core\Routing\RequestContext;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * The form for the "General" tab in CU Boulder site settings.
+ *
+ * While "Pages" could eventually be split off into its own tab, the settings
+ * are found under "General", at least for now. "General" and "Pages" require
+ * different permissions to access.
  */
 class GeneralForm extends ConfigFormBase {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
+
+  /**
+   * The path alias manager.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * The path validator.
+   *
+   * @var \Drupal\Core\Path\PathValidatorInterface
+   */
+  protected $pathValidator;
+
+  /**
+   * The request context.
+   *
+   * @var \Drupal\Core\Routing\RequestContext
+   */
+  protected $requestContext;
 
   /**
    * The site configuration service defined in this module.
@@ -25,11 +61,23 @@ class GeneralForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
+   *   The path alias manager.
+   * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+   *   The path validator.
+   * @param \Drupal\Core\Routing\RequestContext $request_context
+   *   The request context.
    * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
    *   The site configuration service defined in this module.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, SiteConfiguration $service) {
+  public function __construct(ConfigFactoryInterface $config_factory, AccountInterface $user, AliasManagerInterface $alias_manager, PathValidatorInterface $path_validator, RequestContext $request_context, SiteConfiguration $service) {
     parent::__construct($config_factory);
+    $this->user = $user;
+    $this->aliasManager = $alias_manager;
+    $this->pathValidator = $path_validator;
+    $this->requestContext = $request_context;
     $this->service = $service;
   }
 
@@ -44,6 +92,10 @@ class GeneralForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('current_user'),
+      $container->get('path_alias.manager'),
+      $container->get('path.validator'),
+      $container->get('router.request_context'),
       $container->get('ucb_site_configuration')
     );
   }
@@ -64,72 +116,106 @@ class GeneralForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @see \Drupal\system\Form\SiteInformationForm::buildForm
+   *   Contains the definition of a home page field.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $configuration = $this->service->getConfiguration();
     $settings = $this->service->getSettings();
-    $siteTypeOptions = $configuration->get('site_type_options');
-    $siteAffiliationOptions = array_filter($configuration->get('site_affiliation_options'), function ($value) {
-      return !$value['type_restricted'];
-    });
-    $form['site_name'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Site name'),
-      '#default_value' => $this->config('system.site')->get('name'),
-      '#required' => TRUE,
-    ];
-    $form['site_type'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Site type'),
-      '#default_value' => $settings->get('site_type'),
-      '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
-        return $value['label'];
-      }, $siteTypeOptions)),
-      '#required' => FALSE,
-    ];
-    $affiliationHidesOn = [];
-    foreach ($siteTypeOptions as $siteTypeId => $siteType) {
-      if (isset($siteType['affiliation'])) {
-        array_push($affiliationHidesOn, [':input[name="site_type"]' => ['value' => $siteTypeId]]);
+    $systemSiteSettings = $this->config('system.site');
+    if ($this->user->hasPermission('edit ucb site general')) {
+      $siteTypeOptions = $configuration->get('site_type_options');
+      $siteAffiliationOptions = array_filter($configuration->get('site_affiliation_options'), function ($value) {
+        return !$value['type_restricted'];
+      });
+      $form['site_name'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Site name'),
+        '#default_value' => $systemSiteSettings->get('name'),
+        '#required' => TRUE,
+      ];
+      $form['site_type'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Type'),
+        '#default_value' => $settings->get('site_type'),
+        '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
+          return $value['label'];
+        }, $siteTypeOptions)),
+        '#required' => FALSE,
+      ];
+      $affiliationHidesOn = [];
+      foreach ($siteTypeOptions as $siteTypeId => $siteType) {
+        if (isset($siteType['affiliation'])) {
+          array_push($affiliationHidesOn, [':input[name="site_type"]' => ['value' => $siteTypeId]]);
+        }
+      }
+      $form['site_affiliation_container'] = [
+        '#type' => 'container',
+        '#states' => [
+          'invisible' => $affiliationHidesOn,
+        ],
+        'site_affiliation' => [
+          '#type' => 'select',
+          '#title' => $this->t('Affiliation'),
+          '#default_value' => $settings->get('site_affiliation'),
+          '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
+                    return $value['label'];
+          }, $siteAffiliationOptions), ['custom' => $this->t('Custom')]),
+          '#required' => FALSE,
+        ],
+        'site_affiliation_custom' => [
+          '#type' => 'fieldset',
+          '#description' => $this->t('Define a title and optional URL for the custom affiliation.'),
+          '#states' => [
+            'visible' => [[':input[name="site_affiliation"]' => ['value' => 'custom']]],
+          ],
+          'site_affiliation_label' => [
+            '#type' => 'textfield',
+            '#title' => $this->t('Title'),
+            '#default_value' => $settings->get('site_affiliation_label'),
+            '#required' => FALSE,
+            '#maxlength' => 255,
+          ],
+          'site_affiliation_url' => [
+            '#type' => 'textfield',
+            '#title' => $this->t('URL'),
+            '#default_value' => $settings->get('site_affiliation_url'),
+            '#required' => FALSE,
+            '#maxlength' => 255,
+          ],
+        ],
+      ];
+    }
+    if ($this->user->hasPermission('edit ucb site pages')) {
+      $form['site_frontpage'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Home page'),
+        '#default_value' => $this->aliasManager->getAliasByPath($systemSiteSettings->get('page.front')),
+        '#required' => TRUE,
+        '#size' => 40,
+        '#description' => $this->t('Specify a relative URL to display as the home page.'),
+        '#field_prefix' => $this->requestContext->getCompleteBaseUrl(),
+      ];
+    }
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see \Drupal\system\Form\SiteInformationForm::validateForm
+   *   Contains the validation of a home page path.
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    if ($this->user->hasPermission('edit ucb site pages')) {
+      if (($value = $form_state->getValue('site_frontpage')) && $value[0] !== '/') {
+        $form_state->setErrorByName('site_frontpage', $this->t("The path '%path' has to start with a slash.", ['%path' => $form_state->getValue('site_frontpage')]));
+      }
+      if (!$this->pathValidator->isValid($form_state->getValue('site_frontpage'))) {
+        $form_state->setErrorByName('site_frontpage', $this->t("The path '%path' is invalid.", ['%path' => $form_state->getValue('site_frontpage')]));
       }
     }
-    $form['site_affiliation_container'] = [
-      '#type' => 'container',
-      '#states' => [
-        'invisible' => $affiliationHidesOn,
-      ],
-      'site_affiliation' => [
-        '#type' => 'select',
-        '#title' => $this->t('Site affiliation'),
-        '#default_value' => $settings->get('site_affiliation'),
-        '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
-                  return $value['label'];
-        }, $siteAffiliationOptions), ['custom' => $this->t('Custom')]),
-        '#required' => FALSE,
-      ],
-      'site_affiliation_custom' => [
-        '#type' => 'fieldset',
-        '#description' => $this->t('Define a title and optional URL for the custom site affiliation.'),
-        '#states' => [
-          'visible' => [[':input[name="site_affiliation"]' => ['value' => 'custom']]],
-        ],
-        'site_affiliation_label' => [
-          '#type' => 'textfield',
-          '#title' => $this->t('Title'),
-          '#default_value' => $settings->get('site_affiliation_label'),
-          '#required' => FALSE,
-          '#maxlength' => 255,
-        ],
-        'site_affiliation_url' => [
-          '#type' => 'textfield',
-          '#title' => $this->t('URL'),
-          '#default_value' => $settings->get('site_affiliation_url'),
-          '#required' => FALSE,
-          '#maxlength' => 255,
-        ],
-      ],
-    ];
-    return parent::buildForm($form, $form_state);
   }
 
   /**
@@ -137,19 +223,24 @@ class GeneralForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $configuration = $this->service->getConfiguration();
-    $siteTypeOptions = $configuration->get('site_type_options');
-    $this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
-    $siteTypeId = $form_state->getValue('site_type');
-    $siteAffiliationId = $form_state->getValue('site_affiliation');
-    if ($siteTypeId && isset($siteTypeOptions[$siteTypeId]) && isset($siteTypeOptions[$siteTypeId]['affiliation'])) {
-      $siteAffiliationId = $siteTypeOptions[$siteTypeId]['affiliation'];
+    if ($this->user->hasPermission('edit ucb site general')) {
+      $siteTypeOptions = $configuration->get('site_type_options');
+      $this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
+      $siteTypeId = $form_state->getValue('site_type');
+      $siteAffiliationId = $form_state->getValue('site_affiliation');
+      if ($siteTypeId && isset($siteTypeOptions[$siteTypeId]) && isset($siteTypeOptions[$siteTypeId]['affiliation'])) {
+        $siteAffiliationId = $siteTypeOptions[$siteTypeId]['affiliation'];
+      }
+      $this->config('ucb_site_configuration.settings')
+        ->set('site_type', $siteTypeId)
+        ->set('site_affiliation', $siteAffiliationId)
+        ->set('site_affiliation_label', $form_state->getValue('site_affiliation_label'))
+        ->set('site_affiliation_url', $form_state->getValue('site_affiliation_url'))
+        ->save();
     }
-    $this->config('ucb_site_configuration.settings')
-      ->set('site_type', $siteTypeId)
-      ->set('site_affiliation', $siteAffiliationId)
-      ->set('site_affiliation_label', $form_state->getValue('site_affiliation_label'))
-      ->set('site_affiliation_url', $form_state->getValue('site_affiliation_url'))
-      ->save();
+    if ($this->user->hasPermission('edit ucb site pages')) {
+      $this->config('system.site')->set('page.front', $form_state->getValue('site_frontpage'))->save();
+    }
     parent::submitForm($form, $form_state);
   }
 

--- a/src/Form/GeneralForm.php
+++ b/src/Form/GeneralForm.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\GeneralForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -13,137 +8,149 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * The form for the "General" tab in CU Boulder site settings.
+ */
 class GeneralForm extends ConfigFormBase {
 
-	/**
-	 * The user site configuration service defined in this module.
-	 *
-	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
-	 */
-	protected $service;
+  /**
+   * The site configuration service defined in this module.
+   *
+   * @var \Drupal\ucb_site_configuration\SiteConfiguration
+   */
+  protected $service;
 
-	/**
-	 * Constructs a GeneralForm object.
-	 *
-	 * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-	 *   The config factory.
-	 * @param \Drupal\ucb_site_configuration\UserInviteHelperService $helper
-	 *   The user invite helper service defined in this module.
-	 */
-	public function __construct(ConfigFactoryInterface $config_factory, SiteConfiguration $service) {
-		parent::__construct($config_factory);
-		$this->service = $service;
-	}
+  /**
+   * Constructs a GeneralForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+   *   The site configuration service defined in this module.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, SiteConfiguration $service) {
+    parent::__construct($config_factory);
+    $this->service = $service;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-	 *   The container that allows getting any needed services.
-	 *
-	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
-	 */
-	public static function create(ContainerInterface $container) {
-		return new static(
-			$container->get('config.factory'),
-			$container->get('ucb_site_configuration')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container that allows getting any needed services.
+   *
+   * @link https://www.drupal.org/node/2133171 For more on dependency injection
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('ucb_site_configuration')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	protected function getEditableConfigNames() {
-		return ['system.site', 'ucb_site_configuration.settings'];
-	}
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['system.site', 'ucb_site_configuration.settings'];
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getFormId() {
-		return 'ucb_site_configuration_general_form';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ucb_site_configuration_general_form';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function buildForm(array $form, FormStateInterface $form_state) {
-		$configuration = $this->service->getConfiguration();
-		$settings = $this->service->getSettings();
-		$siteTypeOptions = $configuration->get('site_type_options');
-		$siteAffiliationOptions = array_filter($configuration->get('site_affiliation_options'), function ($value) { return !$value['type_restricted']; });
-		$form['site_name'] = [
-			'#type' => 'textfield',
-			'#title' => $this->t('Site name'),
-			'#default_value' => $this->config('system.site')->get('name'),
-			'#required' => TRUE
-		];
-		$form['site_type'] = [
-			'#type' => 'select',
-			'#title' => $this->t('Site type'),
-			'#default_value' => $settings->get('site_type'),
-			'#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) { return $value['label']; }, $siteTypeOptions)),
-			'#required' => FALSE
-		];
-		$affiliationHidesOn = [];
-		foreach ($siteTypeOptions as $siteTypeId => $siteType) {
-			if (isset($siteType['affiliation']))
-				array_push($affiliationHidesOn, [':input[name="site_type"]' => ['value' => $siteTypeId]]);
-		}
-		$form['site_affiliation_container'] = [
-			'#type' => 'container',
-			'#states' => [
-				'invisible' => $affiliationHidesOn
-			],
-			'site_affiliation' => [
-				'#type' => 'select',
-				'#title' => $this->t('Site affiliation'),
-				'#default_value' => $settings->get('site_affiliation'),
-				'#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) { return $value['label']; }, $siteAffiliationOptions), ['custom' =>  $this->t('Custom')]),
-				'#required' => FALSE
-			],
-			'site_affiliation_custom' => [
-				'#type' => 'fieldset',
-				'#description' => $this->t('Define a title and optional URL for the custom site affiliation.'),
-				'#states' => [
-					'visible' => [[':input[name="site_affiliation"]' => ['value' => 'custom']]]
-				],
-				'site_affiliation_label' => [
-					'#type' => 'textfield',
-					'#title' => $this->t('Title'),
-					'#default_value' => $settings->get('site_affiliation_label'),
-					'#required' => FALSE,
-					'#maxlength' => 255
-				],
-				'site_affiliation_url' => [
-					'#type' => 'textfield',
-					'#title' => $this->t('URL'),
-					'#default_value' => $settings->get('site_affiliation_url'),
-					'#required' => FALSE,
-					'#maxlength' => 255
-				]
-			]
-		];
-		return parent::buildForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $configuration = $this->service->getConfiguration();
+    $settings = $this->service->getSettings();
+    $siteTypeOptions = $configuration->get('site_type_options');
+    $siteAffiliationOptions = array_filter($configuration->get('site_affiliation_options'), function ($value) {
+      return !$value['type_restricted'];
+    });
+    $form['site_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Site name'),
+      '#default_value' => $this->config('system.site')->get('name'),
+      '#required' => TRUE,
+    ];
+    $form['site_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Site type'),
+      '#default_value' => $settings->get('site_type'),
+      '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
+        return $value['label'];
+      }, $siteTypeOptions)),
+      '#required' => FALSE,
+    ];
+    $affiliationHidesOn = [];
+    foreach ($siteTypeOptions as $siteTypeId => $siteType) {
+      if (isset($siteType['affiliation'])) {
+        array_push($affiliationHidesOn, [':input[name="site_type"]' => ['value' => $siteTypeId]]);
+      }
+    }
+    $form['site_affiliation_container'] = [
+      '#type' => 'container',
+      '#states' => [
+        'invisible' => $affiliationHidesOn,
+      ],
+      'site_affiliation' => [
+        '#type' => 'select',
+        '#title' => $this->t('Site affiliation'),
+        '#default_value' => $settings->get('site_affiliation'),
+        '#options' => array_merge(['' => $this->t('- None -')], array_map(function ($value) {
+                  return $value['label'];
+        }, $siteAffiliationOptions), ['custom' => $this->t('Custom')]),
+        '#required' => FALSE,
+      ],
+      'site_affiliation_custom' => [
+        '#type' => 'fieldset',
+        '#description' => $this->t('Define a title and optional URL for the custom site affiliation.'),
+        '#states' => [
+          'visible' => [[':input[name="site_affiliation"]' => ['value' => 'custom']]],
+        ],
+        'site_affiliation_label' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('Title'),
+          '#default_value' => $settings->get('site_affiliation_label'),
+          '#required' => FALSE,
+          '#maxlength' => 255,
+        ],
+        'site_affiliation_url' => [
+          '#type' => 'textfield',
+          '#title' => $this->t('URL'),
+          '#default_value' => $settings->get('site_affiliation_url'),
+          '#required' => FALSE,
+          '#maxlength' => 255,
+        ],
+      ],
+    ];
+    return parent::buildForm($form, $form_state);
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$configuration = $this->service->getConfiguration();
-		$siteTypeOptions = $configuration->get('site_type_options');
-		$this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
-		$siteTypeId = $form_state->getValue('site_type');
-		$siteAffiliationId = $form_state->getValue('site_affiliation');
-		if ($siteTypeId && isset($siteTypeOptions[$siteTypeId]) && isset($siteTypeOptions[$siteTypeId]['affiliation']))
-			$siteAffiliationId = $siteTypeOptions[$siteTypeId]['affiliation'];
-		$this->config('ucb_site_configuration.settings')
-			->set('site_type', $siteTypeId)
-			->set('site_affiliation', $siteAffiliationId)
-			->set('site_affiliation_label', $form_state->getValue('site_affiliation_label'))
-			->set('site_affiliation_url', $form_state->getValue('site_affiliation_url'))
-			->save();
-		parent::submitForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $configuration = $this->service->getConfiguration();
+    $siteTypeOptions = $configuration->get('site_type_options');
+    $this->config('system.site')->set('name', $form_state->getValue('site_name'))->save();
+    $siteTypeId = $form_state->getValue('site_type');
+    $siteAffiliationId = $form_state->getValue('site_affiliation');
+    if ($siteTypeId && isset($siteTypeOptions[$siteTypeId]) && isset($siteTypeOptions[$siteTypeId]['affiliation'])) {
+      $siteAffiliationId = $siteTypeOptions[$siteTypeId]['affiliation'];
+    }
+    $this->config('ucb_site_configuration.settings')
+      ->set('site_type', $siteTypeId)
+      ->set('site_affiliation', $siteAffiliationId)
+      ->set('site_affiliation_label', $form_state->getValue('site_affiliation_label'))
+      ->set('site_affiliation_url', $form_state->getValue('site_affiliation_url'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
 }

--- a/src/Form/RelatedArticlesForm.php
+++ b/src/Form/RelatedArticlesForm.php
@@ -1,124 +1,124 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Form\RelatedArticlesForm.
- */
-
 namespace Drupal\ucb_site_configuration\Form;
 
-use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\ucb_site_configuration\SiteConfiguration;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * The form for the "Related articles" tab in CU Boulder site settings.
+ */
 class RelatedArticlesForm extends ConfigFormBase {
 
-	/**
-	 * The entity type manager.
-	 *
-	 * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-	 */
-	protected $entityTypeManager;
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
 
-	/**
-	 * The user site configuration service defined in this module.
-	 *
-	 * @var \Drupal\ucb_site_configuration\SiteConfiguration
-	 */
-	protected $service;
+  /**
+   * The site configuration service defined in this module.
+   *
+   * @var \Drupal\ucb_site_configuration\SiteConfiguration
+   */
+  protected $service;
 
-	/**
-	 * Constructs a RelatedArticlesForm object.
-	 * 
-	 * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   	 *   The entity type manager.
-	 * 
-	 * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
-	 *   The service defined in this module.
-	 */
-	public function __construct(EntityTypeManagerInterface $entityTypeManager, SiteConfiguration $service) {
-		$this->entityTypeManager = $entityTypeManager;
-		$this->service = $service;
-	}
+  /**
+   * Constructs a RelatedArticlesForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\ucb_site_configuration\SiteConfiguration $service
+   *   The site configuration service defined in this module.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, SiteConfiguration $service) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->service = $service;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-	 *   The container that allows getting any needed services.
-	 *
-	 * @link https://www.drupal.org/node/2133171 For more on dependency injection
-	 */
-	public static function create(ContainerInterface $container) {
-		return new static(
-			$container->get('entity_type.manager'),
-			$container->get('ucb_site_configuration')
-		);
-	}
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container that allows getting any needed services.
+   *
+   * @link https://www.drupal.org/node/2133171 For more on dependency injection
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+    $container->get('entity_type.manager'),
+    $container->get('ucb_site_configuration')
+    );
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getFormId() {
-		return 'ucb_site_configuration_related_articles_form';
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'ucb_site_configuration_related_articles_form';
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	protected function getEditableConfigNames() {
-		return ['ucb_site_configuration.settings'];
-	}
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['ucb_site_configuration.settings'];
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function buildForm(array $form, FormStateInterface $form_state) {
-		$settings = $this->service->getSettings();
-		$entityStorage = $this->entityTypeManager->getStorage('taxonomy_term');
-		$categoryTerms = $entityStorage->loadByProperties(['vid' => 'category']);
-		$categoryOptions = [];
-		$tagTerms = $entityStorage->loadByProperties(['vid' => 'tags']);
-		$tagOptions = [];
-		foreach ($categoryTerms as $categoryTerm)
-			$categoryOptions[$categoryTerm->id()] = $categoryTerm->label();
-		foreach ($tagTerms as $tagTerm)
-			$tagOptions[$tagTerm->id()] = $tagTerm->label();
-		$form['enabled_by_default'] = [
-			'#type' => 'checkbox',
-			'#title' => $this->t('Enable related articles by default for new articles'),
-			'#description' => $this->t('If enabled, related articles will default to on when creating a new article. A content author may still turn on or off related articles manually for an individual article.'),
-			'#default_value' => $settings->get('related_articles_enabled_by_default') ?? FALSE,
-			'#required' => FALSE
-		];
-		$form['exclude_categories'] = [
-			'#type' => 'checkboxes',
-			'#title' => $this->t('Exclude categories'),
-			'#default_value' => $settings->get('related_articles_exclude_categories') ?? [],
-			'#options' => $categoryOptions,
-			'#required' => FALSE
-		];
-		$form['exclude_tags'] = [
-			'#type' => 'checkboxes',
-			'#title' => $this->t('Exclude tags'),
-			'#default_value' => $settings->get('related_articles_exclude_tags') ?? [],
-			'#options' => $tagOptions,
-			'#required' => FALSE
-		];
-		return parent::buildForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $settings = $this->service->getSettings();
+    $entityStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $categoryTerms = $entityStorage->loadByProperties(['vid' => 'category']);
+    $categoryOptions = [];
+    $tagTerms = $entityStorage->loadByProperties(['vid' => 'tags']);
+    $tagOptions = [];
+    foreach ($categoryTerms as $categoryTerm) {
+      $categoryOptions[$categoryTerm->id()] = $categoryTerm->label();
+    }
+    foreach ($tagTerms as $tagTerm) {
+      $tagOptions[$tagTerm->id()] = $tagTerm->label();
+    }
+    $form['enabled_by_default'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable related articles by default for new articles'),
+      '#description' => $this->t('If enabled, related articles will default to on when creating a new article. A content author may still turn on or off related articles manually for an individual article.'),
+      '#default_value' => $settings->get('related_articles_enabled_by_default') ?? FALSE,
+      '#required' => FALSE,
+    ];
+    $form['exclude_categories'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Exclude categories'),
+      '#default_value' => $settings->get('related_articles_exclude_categories') ?? [],
+      '#options' => $categoryOptions,
+      '#required' => FALSE,
+    ];
+    $form['exclude_tags'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Exclude tags'),
+      '#default_value' => $settings->get('related_articles_exclude_tags') ?? [],
+      '#options' => $tagOptions,
+      '#required' => FALSE,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function submitForm(array &$form, FormStateInterface $form_state) {
-		$this->config('ucb_site_configuration.settings')
-			->set('related_articles_enabled_by_default', $form_state->getValue('enabled_by_default'))
-			->set('related_articles_exclude_categories', array_keys(array_filter($form_state->getValue('exclude_categories'))))
-			->set('related_articles_exclude_tags', array_keys(array_filter($form_state->getValue('exclude_tags'))))
-			->save();
-		parent::submitForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('ucb_site_configuration.settings')
+      ->set('related_articles_enabled_by_default', $form_state->getValue('enabled_by_default'))
+      ->set('related_articles_exclude_categories', array_keys(array_filter($form_state->getValue('exclude_categories'))))
+      ->set('related_articles_exclude_tags', array_keys(array_filter($form_state->getValue('exclude_tags'))))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
 }

--- a/src/Plugin/Block/SiteInfoBlock.php
+++ b/src/Plugin/Block/SiteInfoBlock.php
@@ -1,60 +1,74 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\Plugin\Block\SiteInfoBlock.
- */
-
 namespace Drupal\ucb_site_configuration\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * The "site info" block, meant to be placed in the site footer.
+ *
  * @Block(
  *   id = "site_info",
  *   admin_label = @Translation("Site Contact Info Footer"),
  * )
  */
-class SiteInfoBlock extends BlockBase {
-	/**
-	 * {@inheritdoc}
-	 */
-	public function build() {
-		$config = \Drupal::config('ucb_site_configuration.contact_info');
-		return [
-			'#data' => [
-				'icons_visible' => $config->get('icons_visible'),
-				'general_visible' => $config->get('general_visible'),
-				'general' => $config->get('general'),
-				'email_visible' => $config->get('email_visible'),
-				'email' => $config->get('email'),
-				'phone_visible' => $config->get('phone_visible'),
-				'phone' => $config->get('phone')
-			]
-		];
-	}
+class SiteInfoBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
-	/**
-	 * {@inheritdoc}
-	 */
-	protected function blockAccess(AccountInterface $account) {
-		return AccessResult::allowedIfHasPermission($account, 'access content');
-	}
+  /**
+   * The connfig factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function blockForm($form, FormStateInterface $form_state) {
-		return parent::blockForm($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function blockSubmit($form, FormStateInterface $form_state) {
-		return parent::blockSubmit($form, $form_state);
-	}
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $config = $this->configFactory->get('ucb_site_configuration.contact_info');
+    return [
+      '#data' => [
+        'icons_visible' => $config->get('icons_visible'),
+        'general_visible' => $config->get('general_visible'),
+        'general' => $config->get('general'),
+        'email_visible' => $config->get('email_visible'),
+        'email' => $config->get('email'),
+        'phone_visible' => $config->get('phone_visible'),
+        'phone' => $config->get('phone'),
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    return AccessResult::allowedIfHasPermission($account, 'access content');
+  }
+
 }

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\ucb_site_configuration\SiteConfiguration.
- */
-
 namespace Drupal\ucb_site_configuration;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -12,399 +7,432 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationManager;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\ucb_site_configuration\Entity\ExternalServiceInclude;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\Url;
 
+/**
+ * The Site Configuration service contains functions used by the module.
+ */
 class SiteConfiguration {
-	use StringTranslationTrait;
+  use StringTranslationTrait;
 
-	/**
-	 * The current user.
-	 *
-	 * @var \Drupal\Core\Session\AccountInterface
-	 */
-	protected $user;
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
 
-	/**
-	 * The module handler.
-	 *
-	 * @var \Drupal\Core\Extension\ModuleHandlerInterface
-	 */
-	protected $moduleHandler;
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
 
-	/**
-	 * The config factory.
-	 *
-	 * @var \Drupal\Core\Config\ConfigFactoryInterface
-	 */
-	protected $configFactory;
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
-	/**
-	 * The entity type manager.
-	 *
-	 * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-	 */
-	protected $entityTypeManager;
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
 
-	/**
-	 * The entity type repository.
-	 *
-	 * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface
-	 */
-	protected $entityTypeRepository;
+  /**
+   * The entity type repository.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeRepositoryInterface
+   */
+  protected $entityTypeRepository;
 
-	/**
-	 * The current route match.
-	 *
-	 * @var \Drupal\Core\Routing\RouteMatchInterface
-	 */
-	protected $currentRouteMatch;
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $currentRouteMatch;
 
-	/**
-	 * The Messenger service.
-	 *
-	 * @var \Drupal\Core\Messenger\MessengerInterface
-	 */
-	protected $messenger;
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
 
-	/**
-	 * Constructs a UserInviteHelperService.
-	 *
-	 * @param \Drupal\Core\Session\AccountInterface $user
-	 *   The current user.
-	 * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-	 *   The module handler.
-	 * @param \Drupal\Core\Extension\ConfigFactoryInterface $config_factory
-	 *   The config factory.
-	 * @param \Drupal\Core\Extension\TranslationManager $string_translation
-	 *   The translation manager.
-	 * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-	 *   The entity type manager.
-	 * @param \Drupal\Core\Entity\EntityTypeRepositoryInterface $entity_type_repository
-	 *   The entity type repository.
-	 * @param \Drupal\Core\Routing\RouteMatchInterface $current_route_match
-	 *   The current route match.
-	 * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-	 *   The messenger service.
-	 */
-	public function __construct(
-		AccountInterface $user,
-		ModuleHandlerInterface $module_handler,
-		ConfigFactoryInterface $config_factory,
-		TranslationManager $string_translation,
-		EntityTypeManagerInterface $entity_type_manager,
-		EntityTypeRepositoryInterface $entity_type_repository,
-		RouteMatchInterface $current_route_match,
-		MessengerInterface $messenger
-	) {
-		$this->user = $user;
-		$this->moduleHandler = $module_handler;
-		$this->configFactory = $config_factory;
-		$this->stringTranslation = $string_translation;
-		$this->entityTypeManager = $entity_type_manager;
-		$this->entityTypeRepository = $entity_type_repository;
-		$this->currentRouteMatch = $current_route_match;
-		$this->messenger = $messenger;
-	}
+  /**
+   * Constructs a UserInviteHelperService.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Extension\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Extension\TranslationManager $string_translation
+   *   The translation manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityTypeRepositoryInterface $entity_type_repository
+   *   The entity type repository.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $current_route_match
+   *   The current route match.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(
+        AccountInterface $user,
+        ModuleHandlerInterface $module_handler,
+        ConfigFactoryInterface $config_factory,
+        TranslationManager $string_translation,
+        EntityTypeManagerInterface $entity_type_manager,
+        EntityTypeRepositoryInterface $entity_type_repository,
+        RouteMatchInterface $current_route_match,
+        MessengerInterface $messenger
+  ) {
+    $this->user = $user;
+    $this->moduleHandler = $module_handler;
+    $this->configFactory = $config_factory;
+    $this->stringTranslation = $string_translation;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeRepository = $entity_type_repository;
+    $this->currentRouteMatch = $current_route_match;
+    $this->messenger = $messenger;
+  }
 
-	/**
-	 * @return string
-	 *   The machine name of the CU Boulder base theme to configure.
-	 */
-	public function getThemeName() {
-		return 'boulder_base';
-	}
+  /**
+   * Gets the machine name of the CU Boulder base theme to configure.
+   *
+   * @return string
+   *   The machine name of the CU Boulder base theme to configure.
+   */
+  public function getThemeName() {
+    return 'boulder_base';
+  }
 
-	/**
-	 * Builds the theme settings form.
-	 * 
-	 * @param array &$form
-	 *   The form build array.
-	 * @param \Drupal\Core\Form\FormStateInterface &$form_state
-	 *   The form state.
-	 */
-	public function buildThemeSettingsForm(array &$form, FormStateInterface &$form_state) {
-		if($this->currentRouteMatch->getRouteName() != 'ucb_site_configuration.appearance_form') { // Accessing these theme settings is no longer possible from the Drupal default theme settings
-			$this->messenger->addMessage($this->t('Please visit <a href="@url">CU Boulder site settings → Appearance</a> to customize the appearance of this site.', ['@url' => Url::fromRoute('ucb_site_configuration.appearance_form')->toString()]));
-			return;
-		}
+  /**
+   * Builds the theme settings form.
+   *
+   * @param array &$form
+   *   The form build array.
+   * @param \Drupal\Core\Form\FormStateInterface &$form_state
+   *   The form state.
+   */
+  public function buildThemeSettingsForm(array &$form, FormStateInterface &$form_state) {
+    // Accessing these theme settings is no longer possible from the Drupal
+    // default theme settings.
+    if ($this->currentRouteMatch->getRouteName() != 'ucb_site_configuration.appearance_form') {
+      $this->messenger->addMessage($this->t('Please visit <a href="@url">CU Boulder site settings → Appearance</a> to customize the appearance of this site.', ['@url' => Url::fromRoute('ucb_site_configuration.appearance_form')->toString()]));
+      return;
+    }
 
-		$themeName = $this->getThemeName();
+    $themeName = $this->getThemeName();
 
-		$form['ucb_campus_header_color'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('CU Boulder campus header color'),
-			'#default_value'  => theme_get_setting('ucb_campus_header_color', $themeName),
-			'#options'        => [
-				$this->t('Black'),
-				$this->t('White')
-			],
-			'#description'    => $this->t('Select the color for the header background for the campus branding information at the top of the page.')
-		];
+    $form['ucb_campus_header_color'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('CU Boulder campus header color'),
+      '#default_value'  => theme_get_setting('ucb_campus_header_color', $themeName),
+      '#options'        => [
+        $this->t('Black'),
+        $this->t('White'),
+      ],
+      '#description'    => $this->t('Select the color for the header background for the campus branding information at the top of the page.'),
+    ];
 
-		$form['ucb_header_color'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('CU Boulder site header color'),
-			'#default_value'  => theme_get_setting('ucb_header_color', $themeName),
-			'#options'        => [
-				$this->t('Black'),
-				$this->t('White'),
-				$this->t('Light'),
-				$this->t('Dark')
-			],
-			'#description'    => $this->t('Select the color for the header background for the site information at the top of the page.')
-		];
+    $form['ucb_header_color'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('CU Boulder site header color'),
+      '#default_value'  => theme_get_setting('ucb_header_color', $themeName),
+      '#options'        => [
+        $this->t('Black'),
+        $this->t('White'),
+        $this->t('Light'),
+        $this->t('Dark'),
+      ],
+      '#description'    => $this->t('Select the color for the header background for the site information at the top of the page.'),
+    ];
 
-		$form['ucb_menu_style'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('Menu style'),
-			'#default_value'  => theme_get_setting('ucb_menu_style', $themeName) ?? 'default',
-			'#options'        => [
-				'default' => $this->t('Default'),
-				'highlight'  => $this->t('Highlight'),
-				'ivory'  => $this->t('Ivory'),
-				'layers'  => $this->t('Layers'),
-				'minimal'  => $this->t('Minimal'),
-				'modern'  => $this->t('Modern'),
-				'rise'  => $this->t('Rise'),
-				'simple'  => $this->t('Simple'),
-				'shadow'  => $this->t('Shadow'),
-				'spirit'  => $this->t('Spirit'),
-				'swatch'  => $this->t('Swatch'),
-				'tradition'  => $this->t('Tradition')
-			],
-			'#description'    => $this->t('Select a style for the main navigation menu.')
-		];
+    $form['ucb_menu_style'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Menu style'),
+      '#default_value'  => theme_get_setting('ucb_menu_style', $themeName) ?? 'default',
+      '#options'        => [
+        'default' => $this->t('Default'),
+        'highlight'  => $this->t('Highlight'),
+        'ivory'  => $this->t('Ivory'),
+        'layers'  => $this->t('Layers'),
+        'minimal'  => $this->t('Minimal'),
+        'modern'  => $this->t('Modern'),
+        'rise'  => $this->t('Rise'),
+        'simple'  => $this->t('Simple'),
+        'shadow'  => $this->t('Shadow'),
+        'spirit'  => $this->t('Spirit'),
+        'swatch'  => $this->t('Swatch'),
+        'tradition'  => $this->t('Tradition'),
+      ],
+      '#description'    => $this->t('Select a style for the main navigation menu.'),
+    ];
 
-		$form['ucb_sidebar_position'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('Where to show sidebar content on a page'),
-			'#default_value'  => theme_get_setting('ucb_sidebar_position', $themeName),
-			'#options'        => [
-				$this->t('Left'),
-				$this->t('Right')
-			],
-			'#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.')
-		];
+    $form['ucb_sidebar_position'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Where to show sidebar content on a page'),
+      '#default_value'  => theme_get_setting('ucb_sidebar_position', $themeName),
+      '#options'        => [
+        $this->t('Left'),
+        $this->t('Right'),
+      ],
+      '#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
+    ];
 
-		$form['ucb_rave_alerts'] = [
-			'#type'           => 'checkbox',
-			'#title'          => $this->t('Show campus-wide alerts'),
-			'#default_value'  => theme_get_setting('ucb_rave_alerts', $themeName),
-			'#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.')
-		];
+    $form['ucb_rave_alerts'] = [
+      '#type'           => 'checkbox',
+      '#title'          => $this->t('Show campus-wide alerts'),
+      '#default_value'  => theme_get_setting('ucb_rave_alerts', $themeName),
+      '#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.'),
+    ];
 
-		$form['ucb_breadcrumb_nav'] = [
-			'#type'           => 'checkbox',
-			'#title'          => $this->t('Show breadcrumb navigation on pages'),
-			'#default_value'  => theme_get_setting('ucb_breadcrumb_nav', $themeName),
-			'#description'    => $this->t('If enabled, the breadcrumb navigation will be shown at the top of pages, helping visitors find their way around the site.')
-		];
+    $form['ucb_breadcrumb_nav'] = [
+      '#type'           => 'checkbox',
+      '#title'          => $this->t('Show breadcrumb navigation on pages'),
+      '#default_value'  => theme_get_setting('ucb_breadcrumb_nav', $themeName),
+      '#description'    => $this->t('If enabled, the breadcrumb navigation will be shown at the top of pages, helping visitors find their way around the site.'),
+    ];
 
-		$form['ucb_sticky_menu'] = [
-			'#type'           => 'checkbox',
-			'#title'          => $this->t('Show sticky menu'),
-			'#default_value'  => theme_get_setting('ucb_sticky_menu', $themeName),
-			'#description'    => $this->t('The sticky menu appears at the top of the page when scrolling on large-screen devices, allowing for quick access to links.')
-		];
+    $form['ucb_sticky_menu'] = [
+      '#type'           => 'checkbox',
+      '#title'          => $this->t('Show sticky menu'),
+      '#default_value'  => theme_get_setting('ucb_sticky_menu', $themeName),
+      '#description'    => $this->t('The sticky menu appears at the top of the page when scrolling on large-screen devices, allowing for quick access to links.'),
+    ];
 
-		$form['ucb_gtm_account'] = [
-			'#type'           => 'textfield',
-			'#title'          => $this->t('GTM Account Number'),
-			'#default_value'  => theme_get_setting('ucb_gtm_account', $themeName),
-			'#description'    => $this->t('Google Tag Manager account number e.g. GTM-123456.'),
-		];
+    $form['ucb_gtm_account'] = [
+      '#type'           => 'textfield',
+      '#title'          => $this->t('GTM Account Number'),
+      '#default_value'  => theme_get_setting('ucb_gtm_account', $themeName),
+      '#description'    => $this->t('Google Tag Manager account number e.g. GTM-123456.'),
+    ];
 
-		$form['ucb_secondary_menu_position'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('Position of the secondary menu'),
-			'#default_value'  => theme_get_setting('ucb_secondary_menu_position', $themeName),
-			'#options'        => [
-				'inline' => $this->t('Inline with the main navigation'),
-				'above'  => $this->t('Above the main navigation')
-			],
-			'#description'    => $this->t('The secondary menu of this site can be populated with secondary or action links and displayed inline with or above the main navigation.')
-		];
+    $form['ucb_secondary_menu_position'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Position of the secondary menu'),
+      '#default_value'  => theme_get_setting('ucb_secondary_menu_position', $themeName),
+      '#options'        => [
+        'inline' => $this->t('Inline with the main navigation'),
+        'above'  => $this->t('Above the main navigation'),
+      ],
+      '#description'    => $this->t('The secondary menu of this site can be populated with secondary or action links and displayed inline with or above the main navigation.'),
+    ];
 
-		$form['ucb_secondary_menu_button_display'] = [
-			'#type'           => 'checkbox',
-			'#title'          => $this->t('Display links in the secondary menu as buttions'),
-			'#default_value'  => theme_get_setting('ucb_secondary_menu_button_display', $themeName),
-			'#description'    => $this->t('Check this box to display the links in the secondary menu of this site as buttons instead of links.')
-		];
+    $form['ucb_secondary_menu_button_display'] = [
+      '#type'           => 'checkbox',
+      '#title'          => $this->t('Display links in the secondary menu as buttions'),
+      '#default_value'  => theme_get_setting('ucb_secondary_menu_button_display', $themeName),
+      '#description'    => $this->t('Check this box to display the links in the secondary menu of this site as buttons instead of links.'),
+    ];
 
-		// Choose where social share buttons are positioned on each page
-		$form['ucb_social_share_position'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('Where your social media sharing links render'),
-			'#default_value'  => theme_get_setting('ucb_social_share_position', $themeName),
-			'#options'        => [
-				$this->t('None'),
-				$this->t('Left Side (Desktop) / Below Title (Mobile)'),
-				$this->t('Left Side (Desktop) / Below Content (Mobile)'),
-				$this->t('Below Content'),
-				$this->t('Below Title')
-			],
-			'#description'    => $this->t('Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages.')
-		];
-		// Choose date/time format sitewide
-		$form['ucb_date_format'] = [
-			'#type'           => 'select',
-			'#title'          => $this->t('Display settings for Date formats on Articles'),
-			'#default_value'  => theme_get_setting('ucb_date_format', $themeName),
-			'#options'        => [
-				$this->t('Short Date'),
-				$this->t('Medium Date'),
-				$this->t('Long Date'),
-				$this->t('Short Date with Time'),
-				$this->t('Medium Date with Time'),
-				$this->t('Long Date with Time'),
-				$this->t('None - Hide')
-			],
-			'#description'    => $this->t('Select the preferred Global Date/Time format for dates on your site.')
-		];
-		if($this->user->hasPermission('edit ucb site advanced')) {
-			$form['advanced'] = [
-				'#type'  => 'details',
-				'#title' => $this->t('Advanced'),
-				'#open'  => FALSE
-			];
-			// @TODO: Add the custom logo stuff here
-			$form['advanced']['ucb_be_boulder'] = [
-				'#type'           => 'select',
-				'#title'          => $this->t('Where to display the Be Boulder slogan on the site.'),
-				'#default_value'  => theme_get_setting('ucb_be_boulder', $themeName),
-				'#options'        => [
-					$this->t('None'),
-					$this->t('Footer'),
-					$this->t('Header')
-				],
-				'#description'    => $this->t('Check this box if you would like to display the "Be Boulder" slogan in the header.')
-			];
-			$form['advanced']['ucb_secondary_menu_default_links'] = [
-				'#type'           => 'checkbox',
-				'#title'          => $this->t('Display the standard Boulder secondary menu in the header navigation region.'),
-				'#default_value'  => theme_get_setting('ucb_secondary_menu_default_links', $themeName),
-				'#description'    => $this->t('Check this box if you would like to display the default Boulder secondary menu links in the header.')
-			];	
-			$form['advanced']['ucb_footer_menu_default_links'] = [
-				'#type'           => 'checkbox',
-				'#title'          => $this->t('Display the standard Boulder menus in the footer region.'),
-				'#default_value'  => theme_get_setting('ucb_footer_menu_default_links', $themeName),
-				'#description'    => $this->t('Check this box if you would like to display the default Boulder footer menu links in the footer.')
-			];
-		}
-	}
+    // Choose where social share buttons are positioned on each page.
+    $form['ucb_social_share_position'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Where your social media sharing links render'),
+      '#default_value'  => theme_get_setting('ucb_social_share_position', $themeName),
+      '#options'        => [
+        $this->t('None'),
+        $this->t('Left Side (Desktop) / Below Title (Mobile)'),
+        $this->t('Left Side (Desktop) / Below Content (Mobile)'),
+        $this->t('Below Content'),
+        $this->t('Below Title'),
+      ],
+      '#description'    => $this->t('Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages.'),
+    ];
+    // Choose date/time format sitewide.
+    $form['ucb_date_format'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Display settings for Date formats on Articles'),
+      '#default_value'  => theme_get_setting('ucb_date_format', $themeName),
+      '#options'        => [
+        $this->t('Short Date'),
+        $this->t('Medium Date'),
+        $this->t('Long Date'),
+        $this->t('Short Date with Time'),
+        $this->t('Medium Date with Time'),
+        $this->t('Long Date with Time'),
+        $this->t('None - Hide'),
+      ],
+      '#description'    => $this->t('Select the preferred Global Date/Time format for dates on your site.'),
+    ];
+    if ($this->user->hasPermission('edit ucb site advanced')) {
+      $form['advanced'] = [
+        '#type'  => 'details',
+        '#title' => $this->t('Advanced'),
+        '#open'  => FALSE,
+      ];
+      // @todo Add the custom logo stuff here
+      $form['advanced']['ucb_be_boulder'] = [
+        '#type'           => 'select',
+        '#title'          => $this->t('Where to display the Be Boulder slogan on the site.'),
+        '#default_value'  => theme_get_setting('ucb_be_boulder', $themeName),
+        '#options'        => [
+          $this->t('None'),
+          $this->t('Footer'),
+          $this->t('Header'),
+        ],
+        '#description'    => $this->t('Check this box if you would like to display the "Be Boulder" slogan in the header.'),
+      ];
+      $form['advanced']['ucb_secondary_menu_default_links'] = [
+        '#type'           => 'checkbox',
+        '#title'          => $this->t('Display the standard Boulder secondary menu in the header navigation region.'),
+        '#default_value'  => theme_get_setting('ucb_secondary_menu_default_links', $themeName),
+        '#description'    => $this->t('Check this box if you would like to display the default Boulder secondary menu links in the header.'),
+      ];
+      $form['advanced']['ucb_footer_menu_default_links'] = [
+        '#type'           => 'checkbox',
+        '#title'          => $this->t('Display the standard Boulder menus in the footer region.'),
+        '#default_value'  => theme_get_setting('ucb_footer_menu_default_links', $themeName),
+        '#description'    => $this->t('Check this box if you would like to display the default Boulder footer menu links in the footer.'),
+      ];
+    }
+  }
 
-	/**
-	 * @return array
-	 *   The external services options available when creating an external service include.
-	 */
-	public function getExternalServicesOptions() {
-		$externalServicesConfiguration = $this->getConfiguration()->get('external_services') ?? [];
-		$options = [];
-		foreach ($externalServicesConfiguration as $externalServiceName => $externalServiceConfiguration)
-			$options[$externalServiceName] = $externalServiceConfiguration['label'];
-		return $options;
-	}
+  /**
+   * Gets the external services options.
+   *
+   * @return array
+   *   The external services options available when creating an external
+   *   service include.
+   */
+  public function getExternalServicesOptions() {
+    $externalServicesConfiguration = $this->getConfiguration()->get('external_services') ?? [];
+    $options = [];
+    foreach ($externalServicesConfiguration as $externalServiceName => $externalServiceConfiguration) {
+      $options[$externalServiceName] = $externalServiceConfiguration['label'];
+    }
+    return $options;
+  }
 
-	/**
-	 * This helper function attaches site information if called from hook_preprocess in the .module file.
-	 * 
-	 * @param array &$variables
-	 *   The array to add the site information to.
-	 */
-	public function attachSiteInformation(array &$variables) {
-		$configuration = $this->getConfiguration();
-		$settings = $this->getSettings();
-		$siteTypeOptions = $configuration->get('site_type_options');
-		$siteAffiliationOptions = $configuration->get('site_affiliation_options');
-		$variables['site_name'] = $this->configFactory->get('system.site')->get('name');
-		$siteTypeId = $settings->get('site_type');
-		$variables['site_type'] = [
-			'id' => $siteTypeId,
-			'label' => $siteTypeId && isset($siteTypeOptions[$siteTypeId]) ? $siteTypeOptions[$siteTypeId]['label'] : $siteTypeId
-		];
-		$siteAffiliationId = $settings->get('site_affiliation');
-		$siteAffiliationAttribs = $siteAffiliationId == 'custom' ? ['label' => $settings->get('site_affiliation_label'), 'url' => $settings->get('site_affiliation_url')] : ($siteAffiliationId && isset($siteAffiliationOptions[$siteAffiliationId]) ? $siteAffiliationOptions[$siteAffiliationId] : ['label' => $siteAffiliationId ?? '', 'url' => '']);
-		$variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs);	
-	}
+  /**
+   * Attaches site information.
+   *
+   * This function is meant to be called from `hook_preprocess`.
+   *
+   * @param array &$variables
+   *   The array to add the site information to.
+   */
+  public function attachSiteInformation(array &$variables) {
+    $configuration = $this->getConfiguration();
+    $settings = $this->getSettings();
+    $siteTypeOptions = $configuration->get('site_type_options');
+    $siteAffiliationOptions = $configuration->get('site_affiliation_options');
+    $variables['site_name'] = $this->configFactory->get('system.site')->get('name');
+    $siteTypeId = $settings->get('site_type');
+    $variables['site_type'] = [
+      'id' => $siteTypeId,
+      'label' => $siteTypeId && isset($siteTypeOptions[$siteTypeId]) ? $siteTypeOptions[$siteTypeId]['label'] : $siteTypeId,
+    ];
+    $siteAffiliationId = $settings->get('site_affiliation');
+    $siteAffiliationAttribs = $siteAffiliationId == 'custom' ? [
+      'label' => $settings->get('site_affiliation_label'),
+      'url' => $settings->get('site_affiliation_url'),
+    ] : ($siteAffiliationId && isset($siteAffiliationOptions[$siteAffiliationId]) ? $siteAffiliationOptions[$siteAffiliationId] : [
+      'label' => $siteAffiliationId ?? '',
+      'url' => '',
+    ]);
+    $variables['site_affiliation'] = array_merge(['id' => $siteAffiliationId], $siteAffiliationAttribs);
+  }
 
-	/**
-	 * This helper function attaches related articles configuration to Articles.
-	 * 
-	 * @param array &$variables
-	 *   The array to add the site information to.
-	 */
-	public function attachRelatedArticlesConfiguration(array &$variables) {
-		$settings = $this->getSettings();
-		$variables['related_articles_exclude_categories'] = $settings->get('related_articles_exclude_categories') ?? [];
-		$variables['related_articles_exclude_tags'] = $settings->get('related_articles_exclude_tags') ?? [];
-	}
+  /**
+   * Attaches related articles configuration to Articles.
+   *
+   * @param array &$variables
+   *   The array to add the site information to.
+   */
+  public function attachRelatedArticlesConfiguration(array &$variables) {
+    $settings = $this->getSettings();
+    $variables['related_articles_exclude_categories'] = $settings->get('related_articles_exclude_categories') ?? [];
+    $variables['related_articles_exclude_tags'] = $settings->get('related_articles_exclude_tags') ?? [];
+  }
 
-	/**
-	 * This helper function attaches external service includes if called from hook_preprocess in the .module file.
-	 * Variables can be referenced from the template using `service_servicename_includes`.
-	 * 
-	 * @param array &$variables
-	 *   The array to add the external service includes to.
-	 * @param \Drupal\node\NodeInterface|null $node
-	 *   A node to match includes that are for specific content. If null, only sitewide includes will be attached.
-	 */
-	public function attachExternalServiceIncludes(array &$variables, NodeInterface $node = NULL) {
-		$storage = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(ExternalServiceInclude::class));
-		$query = $storage->getQuery('OR')->condition('sitewide', TRUE);
-		if ($node)
-			$query->condition('nodes.*', $node->id());
-		$results = $query->execute();
-		/** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface[] */
-		$externalServiceIncludeEntities = $storage->loadMultiple($results);
-		$externalServiceIncludeArrays = [];
-		foreach ($externalServiceIncludeEntities as $externalServiceInclude) {
-			$externalServiceName = $externalServiceInclude->getServiceName();
-			$externalServiceIncludeArrays[$externalServiceName][] = [
-				'id' => $externalServiceInclude->id(),
-				'label' => $externalServiceInclude->label(),
-				'service_name' => $externalServiceName,
-				'service_settings' => $externalServiceInclude->getServiceSettings(),
-				'sitewide' => $externalServiceInclude->isSitewide()
-			];
-		}
-		foreach ($externalServiceIncludeArrays as $externalServiceName => $externalServiceIncludeArray)
-			$variables['service_' . $externalServiceName . '_includes'] = $externalServiceIncludeArray;	
-	}
+  /**
+   * Attaches external service includes.
+   *
+   * This function is meant to be called from `hook_preprocess`. Variables can
+   * be referenced from the template using `service_servicename_includes`.
+   *
+   * @param array &$variables
+   *   The array to add the external service includes to.
+   * @param \Drupal\node\NodeInterface|null $node
+   *   A node to match includes that are for specific content. If null, only
+   *   sitewide includes will be attached.
+   */
+  public function attachExternalServiceIncludes(array &$variables, NodeInterface $node = NULL) {
+    $storage = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(ExternalServiceInclude::class));
+    $query = $storage->getQuery('OR')->condition('sitewide', TRUE);
+    if ($node) {
+      $query->condition('nodes.*', $node->id());
+    }
+    $results = $query->execute();
+    /** @var \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface[] */
+    $externalServiceIncludeEntities = $storage->loadMultiple($results);
+    $externalServiceIncludeArrays = [];
+    foreach ($externalServiceIncludeEntities as $externalServiceInclude) {
+      $externalServiceName = $externalServiceInclude->getServiceName();
+      $externalServiceIncludeArrays[$externalServiceName][] = [
+        'id' => $externalServiceInclude->id(),
+        'label' => $externalServiceInclude->label(),
+        'service_name' => $externalServiceName,
+        'service_settings' => $externalServiceInclude->getServiceSettings(),
+        'sitewide' => $externalServiceInclude->isSitewide(),
+      ];
+    }
+    foreach ($externalServiceIncludeArrays as $externalServiceName => $externalServiceIncludeArray) {
+      $variables['service_' . $externalServiceName . '_includes'] = $externalServiceIncludeArray;
+    }
+  }
 
-	/**
-	 * @return \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface[]
-	 *   All the external service includes that can be added and removed from the content form pages.
-	 */
-	public function getContentAccessibleExternalServiceIncludes() {
-		$storage = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(ExternalServiceInclude::class));
-		$query = $storage->getQuery('AND')->condition('sitewide', FALSE);
-		if (!$this->user->hasPermission('administer ucb external services'))
-			$query->condition('content_editing_enabled', TRUE);
-		return $storage->loadMultiple($query->execute());
-	}
+  /**
+   * Gets the external service includes available on content form pages.
+   *
+   * @return \Drupal\ucb_site_configuration\Entity\ExternalServiceIncludeInterface[]
+   *   All the external service includes that can be added and removed from the
+   *   content form pages.
+   */
+  public function getContentAccessibleExternalServiceIncludes() {
+    $storage = $this->entityTypeManager->getStorage($this->entityTypeRepository->getEntityTypeFromClass(ExternalServiceInclude::class));
+    $query = $storage->getQuery('AND')->condition('sitewide', FALSE);
+    if (!$this->user->hasPermission('administer ucb external services')) {
+      $query->condition('content_editing_enabled', TRUE);
+    }
+    return $storage->loadMultiple($query->execute());
+  }
 
-	/**
-	 * @return \Drupal\Core\Config\ImmutableConfig
-	 *   The configuration of the CU Boulder Site Configuration module.
-	 */
-	public function getConfiguration() {
-		return $this->configFactory->get('ucb_site_configuration.configuration');
-	}
+  /**
+   * Gets the static configuration.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig
+   *   The static configuration of the CU Boulder Site Configuration module.
+   */
+  public function getConfiguration() {
+    return $this->configFactory->get('ucb_site_configuration.configuration');
+  }
 
-	/**
-	 * @return \Drupal\Core\Config\ImmutableConfig
-	 *   The user-modifiable settings of the CU Boulder Site Configuration module.
-	 */
-	public function getSettings() {
-		return $this->configFactory->get('ucb_site_configuration.settings');
-	}
+  /**
+   * Gets the user-modifiable settings.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig
+   *   The user-modifiable settings of the CU Boulder Site Configuration module.
+   */
+  public function getSettings() {
+    return $this->configFactory->get('ucb_site_configuration.settings');
+  }
+
 }

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -8,5 +8,6 @@ dependencies:
   - block
   - file
   - node
+  - path_alias
   - ucb_admin_menus
   - system

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -1,52 +1,60 @@
 <?php
+
+/**
+ * @file
+ * Contains update hooks used by the CU Boulder Site Configuration module.
+ */
+
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * v2.1 – Adds configuration and settings for the site type and affiliation (CuBoulder/tiamat-theme#210, CuBoulder/tiamat-theme#211).
+ * V2.1 – Adds configuration and settings for the site type and affiliation (CuBoulder/tiamat-theme#210, CuBoulder/tiamat-theme#211).
  */
 function ucb_site_configuration_update_9502() {
-	$config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
-	$settings = \Drupal::configFactory()->getEditable('ucb_site_configuration.settings');
-	$yaml = Yaml::parse(file_get_contents(drupal_get_path('module', 'ucb_site_configuration') . '/config/install/ucb_site_configuration.configuration.yml'));
-	if (!is_array($yaml))
-		throw new \RuntimeException('Oh no! Failed to get or parse site type and affiliation configuration YAML.');
-	$config->set('site_type_options', $yaml['site_type_options'])->set('site_affiliation_options', $yaml['site_affiliation_options'])->save();
-	$settings->set('site_type', '')->set('site_affiliation', '')->set('site_affiliation_label', '')->set('site_affiliation_url', '')->save();
+  $config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
+  $settings = \Drupal::configFactory()->getEditable('ucb_site_configuration.settings');
+  $yaml = Yaml::parse(file_get_contents(drupal_get_path('module', 'ucb_site_configuration') . '/config/install/ucb_site_configuration.configuration.yml'));
+  if (!is_array($yaml)) {
+    throw new \RuntimeException('Oh no! Failed to get or parse site type and affiliation configuration YAML.');
+  }
+  $config->set('site_type_options', $yaml['site_type_options'])->set('site_affiliation_options', $yaml['site_affiliation_options'])->save();
+  $settings->set('site_type', '')->set('site_affiliation', '')->set('site_affiliation_label', '')->set('site_affiliation_url', '')->save();
 }
 
 /**
- * v2.1.1 – Removes "Be Boulder slogan" from Appearance settings (CuBoulder/tiamat-theme#230).
+ * V2.1.1 – Removes "Be Boulder slogan" from Appearance settings (CuBoulder/tiamat-theme#230).
  */
 function ucb_site_configuration_update_9503() {
-	$config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
-	$editableThemeSettings = $config->get('editable_theme_settings');
-	$index = array_search('ucb_be_boulder', $editableThemeSettings);
-	if ($index !== false) {
-		array_splice($editableThemeSettings, $index, 1);
-		$config->set('editable_theme_settings', $editableThemeSettings)->save();	
-	}
+  $config = \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration');
+  $editableThemeSettings = $config->get('editable_theme_settings');
+  $index = array_search('ucb_be_boulder', $editableThemeSettings);
+  if ($index !== FALSE) {
+    array_splice($editableThemeSettings, $index, 1);
+    $config->set('editable_theme_settings', $editableThemeSettings)->save();
+  }
 }
 
 /**
- * v2.2 – Admin Helpscout Beacon moved to ucb_admin_menus (CuBoulder/ucb_admin_menus#2).
+ * V2.2 – Admin Helpscout Beacon moved to ucb_admin_menus (CuBoulder/ucb_admin_menus#2).
  */
 function ucb_site_configuration_update_9504() {
-	\Drupal::configFactory()->getEditable('ucb_site_configuration.configuration')->clear('admin_helpscout_beacon_id')->save();
+  \Drupal::configFactory()->getEditable('ucb_site_configuration.configuration')->clear('admin_helpscout_beacon_id')->save();
 }
 
 /**
- * v2.3 – Modififies contact info settings (CuBoulder/tiamat-theme#269).
+ * V2.3 – Modififies contact info settings (CuBoulder/tiamat-theme#269).
  */
 function ucb_site_configuration_update_9505() {
-	\Drupal::configFactory()->getEditable('ucb_site_configuration.contact_info')
-		->clear('address_visible')
-		->clear('address')
-		->set('general_visible', FALSE)
-		->set('general', [
-			[
-				'visible' => FALSE,
-				'label' => '',
-				'value' => [ 'value' => '', 'format' => 'wysiwyg' ]
-			]])
-		->save();
+  \Drupal::configFactory()->getEditable('ucb_site_configuration.contact_info')
+    ->clear('address_visible')
+    ->clear('address')
+    ->set('general_visible', FALSE)
+    ->set('general', [
+      [
+        'visible' => FALSE,
+        'label' => '',
+        'value' => ['value' => '', 'format' => 'wysiwyg'],
+      ],
+    ])
+    ->save();
 }

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -1,109 +1,126 @@
 <?php
 
+/**
+ * @file
+ * Contains functional hooks used by the CU Boulder Site Configuration module.
+ */
+
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
  * Enables external service includes to be referenced from the page template.
+ *
  * Implements hook_preprocess_HOOK().
  */
 function ucb_site_configuration_preprocess_page(array &$variables) {
-	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
-	$service = \Drupal::service('ucb_site_configuration');
-	$service->attachSiteInformation($variables);
-	if (($node = \Drupal::routeMatch()->getParameter('node')) && $node instanceof NodeInterface) {
-		$service->attachExternalServiceIncludes($variables, $node);
-	} else $service->attachExternalServiceIncludes($variables);
-	$variables['#cache']['tags'][] = 'config:ucb_site_configuration.configuration';
-	$variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
+  /** @var \Drupal\ucb_site_configuration\SiteConfiguration */
+  $service = \Drupal::service('ucb_site_configuration');
+  $service->attachSiteInformation($variables);
+  if (($node = \Drupal::routeMatch()->getParameter('node')) && $node instanceof NodeInterface) {
+    $service->attachExternalServiceIncludes($variables, $node);
+  }
+  else {
+    $service->attachExternalServiceIncludes($variables);
+  }
+  $variables['#cache']['tags'][] = 'config:ucb_site_configuration.configuration';
+  $variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
 }
 
 /**
  * Exposes related article configuration to the Article node template.
+ *
  * Implements hook_preprocess_HOOK().
  */
 function ucb_site_configuration_preprocess_node(array &$variables) {
-	/** @var \Drupal\node\NodeInterface */
-	$node = $variables['node'];
-	if ($node->getType() === 'ucb_article') {
-		\Drupal::service('ucb_site_configuration')->attachRelatedArticlesConfiguration($variables);
-		$variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
-	}
+  /** @var \Drupal\node\NodeInterface */
+  $node = $variables['node'];
+  if ($node->getType() === 'ucb_article') {
+    \Drupal::service('ucb_site_configuration')->attachRelatedArticlesConfiguration($variables);
+    $variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
+  }
 }
 
 /**
  * Sets related articles setting to the global setting by default.
- * Implements hook_field_widget_single_element_form_alter().  
- */  
+ *
+ * Implements hook_field_widget_single_element_form_alter().
+ */
 function ucb_site_configuration_field_widget_single_element_form_alter(array &$element, FormStateInterface $form_state, array $context) {
-	if ($context['items']->getFieldDefinition()->getName() === 'field_ucb_related_articles_parag' && !$form_state->getFormObject()->getEntity()->id())
-		$element['subform']['field_ucb_related_articles_bool']['widget']['value']['#default_value'] = \Drupal::service('ucb_site_configuration')->getSettings()->get('related_articles_enabled_by_default') ?? FALSE;	
+  if ($context['items']->getFieldDefinition()->getName() === 'field_ucb_related_articles_parag' && !$form_state->getFormObject()->getEntity()->id()) {
+    $element['subform']['field_ucb_related_articles_bool']['widget']['value']['#default_value'] = \Drupal::service('ucb_site_configuration')->getSettings()->get('related_articles_enabled_by_default') ?? FALSE;
+  }
 }
 
 /**
  * Adds third-party service configuration options to node form sidebars.
+ *
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInterface $form_state) {
-	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
-	$service = \Drupal::service('ucb_site_configuration');
-	/** @var \Drupal\node\NodeInterface */
-	$node = $form_state->getFormObject()->getEntity();
-	$contentAccessibleExternalServiceIncludes = $service->getContentAccessibleExternalServiceIncludes();
-	$contentServicesFieldAllowedOptions = [];
-	$contentServicesFieldDefaultOptions = [];
-	foreach ($contentAccessibleExternalServiceIncludes as $externalServiceInclude) {
-		$includeId = $externalServiceInclude->id();
-		$contentServicesFieldAllowedOptions[$includeId] = $externalServiceInclude->label();
-		if (in_array($node->id(), $externalServiceInclude->getNodeIds()))
-			$contentServicesFieldDefaultOptions[] = $includeId;
-	}
-	/** @var \Symfony\Component\Routing\Route */
-    $siteSettingsRoute = \Drupal::service('router.route_provider')->getRouteByName('entity.ucb_external_service_include.collection');
-	$form['ucb_external_services'] = [
-		'#type' => 'details',
-   		'#title' => t('Third-party services'),
-		'#group' => 'advanced',
-		'#open' => (bool) $contentServicesFieldDefaultOptions,
-		'ucb_external_services_enabled' => [
-			'#type'  => 'checkboxes',
-			'#title' => t('Third-party services'),
-			'#description' => t('A user with permission can <a href="@settings_form_uri">configure third-party services</a> to display here. Third-party services aren\'t included in previews.', ['@settings_form_uri' => $siteSettingsRoute->getPath()]),
-			'#options' => $contentServicesFieldAllowedOptions,
-			'#default_value' => $contentServicesFieldDefaultOptions
-		]
-	];
-	// Binds submit action
-	foreach (array_keys($form['actions']) as $action) {
-		if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-			$form['actions'][$action]['#submit'][] = 'ucb_site_configuration_form_node_form_submit';
-		}
-	}
+  /** @var \Drupal\ucb_site_configuration\SiteConfiguration */
+  $service = \Drupal::service('ucb_site_configuration');
+  /** @var \Drupal\node\NodeInterface */
+  $node = $form_state->getFormObject()->getEntity();
+  $contentAccessibleExternalServiceIncludes = $service->getContentAccessibleExternalServiceIncludes();
+  $contentServicesFieldAllowedOptions = [];
+  $contentServicesFieldDefaultOptions = [];
+  foreach ($contentAccessibleExternalServiceIncludes as $externalServiceInclude) {
+    $includeId = $externalServiceInclude->id();
+    $contentServicesFieldAllowedOptions[$includeId] = $externalServiceInclude->label();
+    if (in_array($node->id(), $externalServiceInclude->getNodeIds())) {
+      $contentServicesFieldDefaultOptions[] = $includeId;
+    }
+  }
+  /** @var \Symfony\Component\Routing\Route */
+  $siteSettingsRoute = \Drupal::service('router.route_provider')->getRouteByName('entity.ucb_external_service_include.collection');
+  $form['ucb_external_services'] = [
+    '#type' => 'details',
+    '#title' => t('Third-party services'),
+    '#group' => 'advanced',
+    '#open' => (bool) $contentServicesFieldDefaultOptions,
+    'ucb_external_services_enabled' => [
+      '#type'  => 'checkboxes',
+      '#title' => t('Third-party services'),
+      '#description' => t('A user with permission can <a href="@settings_form_uri">configure third-party services</a> to display here. Third-party services aren\'t included in previews.', ['@settings_form_uri' => $siteSettingsRoute->getPath()]),
+      '#options' => $contentServicesFieldAllowedOptions,
+      '#default_value' => $contentServicesFieldDefaultOptions,
+    ],
+  ];
+  // Binds submit action.
+  foreach (array_keys($form['actions']) as $action) {
+    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+      $form['actions'][$action]['#submit'][] = 'ucb_site_configuration_form_node_form_submit';
+    }
+  }
 }
 
 /**
  * Saves the third-party services settings when a node is saved.
  */
 function ucb_site_configuration_form_node_form_submit(array &$form, FormStateInterface $form_state) {
-	/** @var \Drupal\ucb_site_configuration\SiteConfiguration */
-	$service = \Drupal::service('ucb_site_configuration');
-	/** @var \Drupal\node\NodeInterface */
-	$node = $form_state->getFormObject()->getEntity();
-	$contentAccessibleExternalServiceIncludes = $service->getContentAccessibleExternalServiceIncludes();
-	$contentServicesFieldSelectedIds = $form_state->getValue('ucb_external_services_enabled');
-	foreach ($contentAccessibleExternalServiceIncludes as $externalServiceInclude) {
-		$includeId = $externalServiceInclude->id();
-		$nodeIds = $externalServiceInclude->getNodeIds();
-		$index = array_search($node->id(), $nodeIds);
-		$isSelected = (bool) $contentServicesFieldSelectedIds[$includeId];
-		if ($isSelected && $index === false) { // add the node to the include
-			$nodeIds[] = $node->id();
-			$externalServiceInclude->set('nodes', $nodeIds);
-			$externalServiceInclude->save();
-		} else if (!$isSelected && $index !== false) { // remove the node from the include
-			unset($nodeIds[$index]);
-			$externalServiceInclude->set('nodes', $nodeIds);
-			$externalServiceInclude->save();
-		}
-	}
+  /** @var \Drupal\ucb_site_configuration\SiteConfiguration */
+  $service = \Drupal::service('ucb_site_configuration');
+  /** @var \Drupal\node\NodeInterface */
+  $node = $form_state->getFormObject()->getEntity();
+  $contentAccessibleExternalServiceIncludes = $service->getContentAccessibleExternalServiceIncludes();
+  $contentServicesFieldSelectedIds = $form_state->getValue('ucb_external_services_enabled');
+  foreach ($contentAccessibleExternalServiceIncludes as $externalServiceInclude) {
+    $includeId = $externalServiceInclude->id();
+    $nodeIds = $externalServiceInclude->getNodeIds();
+    $index = array_search($node->id(), $nodeIds);
+    $isSelected = (bool) $contentServicesFieldSelectedIds[$includeId];
+    // Add the node to the include.
+    if ($isSelected && $index === FALSE) {
+      $nodeIds[] = $node->id();
+      $externalServiceInclude->set('nodes', $nodeIds);
+      $externalServiceInclude->save();
+      // Remove the node from the include.
+    }
+    elseif (!$isSelected && $index !== FALSE) {
+      unset($nodeIds[$index]);
+      $externalServiceInclude->set('nodes', $nodeIds);
+      $externalServiceInclude->save();
+    }
+  }
 }

--- a/ucb_site_configuration.permissions.yml
+++ b/ucb_site_configuration.permissions.yml
@@ -2,6 +2,10 @@ edit ucb site general:
   title: Edit the site general settings
   description: 'Enables editing of the CU Boulder general site settings and information such as the site name, type, and affiliation.'
 
+edit ucb site pages:
+  title: Change the site homepage
+  description: 'Enables changing the site homepage.'
+
 edit ucb site appearance:
   title: Edit the site appearance
   description: 'Enables editing of the CU Boulder site appearance.'

--- a/ucb_site_configuration.routing.yml
+++ b/ucb_site_configuration.routing.yml
@@ -16,7 +16,7 @@ ucb_site_configuration.general_form:
     _form: '\Drupal\ucb_site_configuration\Form\GeneralForm'
     _title: General
   requirements:
-    _permission: edit ucb site general
+    _custom_access: '\Drupal\ucb_site_configuration\Controller\SiteSettingsAccessController::accessGeneral'
   options:
     _admin_route: true
 


### PR DESCRIPTION
This update to CU Boulder Site Configuration:
- Adds a new home page setting to CU Boulder site settings. Resolves CuBoulder/tiamat-theme#506
- Adds a new `edit ucb site pages` permission:
  - Architect, Developer, and Site Manager have been given this new permission. 
  - While "Pages" could eventually be split off into its own tab, the settings are found under "General", at least for now. The existing settings in "General" still require `edit ucb site general` to access.
- Cleans up PHP files in CU Boulder Site Configuration according to Drupal coding standards. Full compliance has not yet been achieved. CuBoulder/ucb_site_configuration#27

Sister PR in: [tiamat10-profile](https://github.com/CuBoulder/tiamat10-profile/pull/30)