### PR TITLE
CU Boulder site configuration 2.5.1

### DIFF
--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -97,12 +97,6 @@ class AppearanceForm extends ThemeSettingsForm {
     $form = parent::buildForm($form, $form_state, $theme);
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $advanced = [];
-      $advanced['ucb_rave_alerts'] = [
-        '#type'           => 'checkbox',
-        '#title'          => $this->t('Show campus-wide alerts'),
-        '#default_value'  => theme_get_setting('ucb_rave_alerts', $theme),
-        '#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.'),
-      ];
       $advanced['custom_logo'] = [
         '#type' => 'container',
       ];

--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -97,6 +97,12 @@ class AppearanceForm extends ThemeSettingsForm {
     $form = parent::buildForm($form, $form_state, $theme);
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $advanced = [];
+      $advanced['ucb_rave_alerts'] = [
+        '#type'           => 'checkbox',
+        '#title'          => $this->t('Show campus-wide alerts'),
+        '#default_value'  => theme_get_setting('ucb_rave_alerts', $theme),
+        '#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.'),
+      ];
       $advanced['custom_logo'] = [
         '#type' => 'container',
       ];

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -195,13 +195,6 @@ class SiteConfiguration {
       '#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
     ];
 
-    $form['ucb_rave_alerts'] = [
-      '#type'           => 'checkbox',
-      '#title'          => $this->t('Show campus-wide alerts'),
-      '#default_value'  => theme_get_setting('ucb_rave_alerts', $themeName),
-      '#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.'),
-    ];
-
     $form['ucb_breadcrumb_nav'] = [
       '#type'           => 'checkbox',
       '#title'          => $this->t('Show breadcrumb navigation on pages'),

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -270,7 +270,12 @@ class SiteConfiguration {
         '#title' => $this->t('Advanced'),
         '#open'  => FALSE,
       ];
-      // @todo Add the custom logo stuff here
+      $form['advanced']['ucb_rave_alerts'] = [
+        '#type'           => 'checkbox',
+        '#title'          => $this->t('Show campus-wide alerts'),
+        '#default_value'  => theme_get_setting('ucb_rave_alerts', $themeName),
+        '#description'    => $this->t('If enabled, campus-wide alerts will be displayed at the top of the site.'),
+      ];
       $form['advanced']['ucb_be_boulder'] = [
         '#type'           => 'select',
         '#title'          => $this->t('Where to display the Be Boulder slogan on the site.'),

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.5'
+version: '2.5.1'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -78,6 +78,7 @@ function ucb_site_configuration_form_node_form_alter(array &$form, FormStateInte
     '#type' => 'details',
     '#title' => t('Third-party services'),
     '#group' => 'advanced',
+    '#weight' => 35,
     '#open' => (bool) $contentServicesFieldDefaultOptions,
     'ucb_external_services_enabled' => [
       '#type'  => 'checkboxes',


### PR DESCRIPTION
This update:
- Moves campus alerts setting into "Advanced". Resolves CuBoulder/ucb_site_configuration#31
- Sets the weight of "Third-party services" in node sidebars to 35, placing it below "URL alias". Resolves CuBoulder/ucb_site_configuration#30
