### PR TITLE
People List Filter Labels as a Global Setting

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -264,6 +264,26 @@ class SiteConfiguration {
       ],
       '#description'    => $this->t('Select the preferred Global Date/Time format for dates on your site.'),
     ];
+    // Custom labels for filters 1-3 on People List Pages
+    $form['ucb_filter_1_label'] = [
+      '#type'           => 'textfield',
+      '#title'          => $this->t('Filter 1 Label'),
+      '#default_value'  => theme_get_setting('ucb_filter_1_label', $themeName),
+      '#description'    => $this->t('Choose the label that will be used for "Filter 1" on People List Pages'),
+    ];
+    $form['ucb_filter_2_label'] = [
+      '#type'           => 'textfield',
+      '#title'          => $this->t('Filter 2 Label'),
+      '#default_value'  => theme_get_setting('ucb_filter_2_label', $themeName),
+      '#description'    => $this->t('Choose the label that will be used for "Filter 2" on People List Pages'),
+    ];
+    $form['ucb_filter_3_label'] = [
+      '#type'           => 'textfield',
+      '#title'          => $this->t('Filter 3 Label'),
+      '#default_value'  => theme_get_setting('ucb_filter_3_label', $themeName),
+      '#description'    => $this->t('Choose the label that will be used for "Filter 3" on People List Pages'),
+    ];
+
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $form['advanced'] = [
         '#type'  => 'details',


### PR DESCRIPTION
Changes the People List `Filter 1`, `Filter 2`, and `Filter 3` custom labels to a Global Setting in Site Configuration, rather than being set per-page. These labels will be set under Configuration => Cu Boulder Site Settings => Appearance and Layout.

Resolves [#543 ](https://github.com/CuBoulder/tiamat-theme/issues/543)

Includes:
- `ucb_site_configuarion` => https://github.com/CuBoulder/ucb_site_configuration/pull/35
-  `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/560
-  `ucb_custom_entities` => https://github.com/CuBoulder/tiamat-custom-entities/pull/87