### PR TITLE
CU Boulder Site Configuration v2.6.1

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -139,7 +139,13 @@ class SiteConfiguration {
 
     $themeName = $this->getThemeName();
 
-    $form['ucb_campus_header_color'] = [
+    $form['header'] = [
+      '#type' => 'details',
+      '#title' => 'Site header and navigation',
+      '#open' => TRUE,
+    ];
+
+    $form['header']['ucb_campus_header_color'] = [
       '#type'           => 'select',
       '#title'          => $this->t('CU Boulder campus header color'),
       '#default_value'  => theme_get_setting('ucb_campus_header_color', $themeName),
@@ -150,7 +156,7 @@ class SiteConfiguration {
       '#description'    => $this->t('Select the color for the header background for the campus branding information at the top of the page.'),
     ];
 
-    $form['ucb_header_color'] = [
+    $form['header']['ucb_header_color'] = [
       '#type'           => 'select',
       '#title'          => $this->t('CU Boulder site header color'),
       '#default_value'  => theme_get_setting('ucb_header_color', $themeName),
@@ -163,7 +169,7 @@ class SiteConfiguration {
       '#description'    => $this->t('Select the color for the header background for the site information at the top of the page.'),
     ];
 
-    $form['ucb_menu_style'] = [
+    $form['header']['ucb_menu_style'] = [
       '#type'           => 'select',
       '#title'          => $this->t('Menu style'),
       '#default_value'  => theme_get_setting('ucb_menu_style', $themeName) ?? 'default',
@@ -184,32 +190,21 @@ class SiteConfiguration {
       '#description'    => $this->t('Select a style for the main navigation menu.'),
     ];
 
-    $form['ucb_sidebar_position'] = [
-      '#type'           => 'select',
-      '#title'          => $this->t('Where to show sidebar content on a page'),
-      '#default_value'  => theme_get_setting('ucb_sidebar_position', $themeName),
-      '#options'        => [
-        $this->t('Left'),
-        $this->t('Right'),
-      ],
-      '#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
-    ];
-
-    $form['ucb_breadcrumb_nav'] = [
+    $form['header']['ucb_breadcrumb_nav'] = [
       '#type'           => 'checkbox',
       '#title'          => $this->t('Show breadcrumb navigation on pages'),
       '#default_value'  => theme_get_setting('ucb_breadcrumb_nav', $themeName),
       '#description'    => $this->t('If enabled, the breadcrumb navigation will be shown at the top of pages, helping visitors find their way around the site.'),
     ];
 
-    $form['ucb_sticky_menu'] = [
+    $form['header']['ucb_sticky_menu'] = [
       '#type'           => 'checkbox',
       '#title'          => $this->t('Show sticky menu'),
       '#default_value'  => theme_get_setting('ucb_sticky_menu', $themeName),
       '#description'    => $this->t('The sticky menu appears at the top of the page when scrolling on large-screen devices, allowing for quick access to links.'),
     ];
 
-    $form['ucb_secondary_menu_position'] = [
+    $form['header']['ucb_secondary_menu_position'] = [
       '#type'           => 'select',
       '#title'          => $this->t('Position of the secondary menu'),
       '#default_value'  => theme_get_setting('ucb_secondary_menu_position', $themeName),
@@ -220,15 +215,49 @@ class SiteConfiguration {
       '#description'    => $this->t('The secondary menu of this site can be populated with secondary or action links and displayed inline with or above the main navigation.'),
     ];
 
-    $form['ucb_secondary_menu_button_display'] = [
+    $form['header']['ucb_secondary_menu_button_display'] = [
       '#type'           => 'checkbox',
       '#title'          => $this->t('Display links in the secondary menu as buttions'),
       '#default_value'  => theme_get_setting('ucb_secondary_menu_button_display', $themeName),
       '#description'    => $this->t('Check this box to display the links in the secondary menu of this site as buttons instead of links.'),
     ];
 
+    $form['content'] = [
+      '#type' => 'details',
+      '#title' => 'Page content',
+      '#open' => TRUE,
+    ];
+
+    $form['content']['ucb_heading_font'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Heading font'),
+      '#default_value'  => theme_get_setting('ucb_heading_font', $themeName) ?? 'bold',
+      '#options'        => [
+        'bold' => $this->t('Bold'),
+        'normal' => $this->t('Normal'),
+      ],
+      '#description'    => $this->t('Headers are bold by default, but can also be set to the same font weight as normal text.'),
+    ];
+
+    $form['misc'] = [
+      '#type' => 'details',
+      '#title' => 'Miscellaneous',
+      '#open' => TRUE,
+    ];
+
+    $form['misc']['ucb_sidebar_position'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Where to show sidebar content on a page'),
+      '#default_value'  => theme_get_setting('ucb_sidebar_position', $themeName),
+      '#options'        => [
+        $this->t('Left'),
+        $this->t('Right'),
+      ],
+      '#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
+    ];
+
     // Choose where social share buttons are positioned on each page.
-    $form['ucb_social_share_position'] = [
+    $form['misc']['ucb_social_share_position'] = [
       '#type'           => 'select',
       '#title'          => $this->t('Where your social media sharing links render'),
       '#default_value'  => theme_get_setting('ucb_social_share_position', $themeName),
@@ -241,6 +270,7 @@ class SiteConfiguration {
       ],
       '#description'    => $this->t('Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages.'),
     ];
+
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $form['advanced'] = [
         '#type'  => 'details',

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -209,8 +209,8 @@ class SiteConfiguration {
       '#title'          => $this->t('Position of the secondary menu'),
       '#default_value'  => theme_get_setting('ucb_secondary_menu_position', $themeName),
       '#options'        => [
-        'inline' => $this->t('Inline with the main navigation'),
         'above'  => $this->t('Above the main navigation'),
+        'inline' => $this->t('Inline with the main navigation'),
       ],
       '#description'    => $this->t('The secondary menu of this site can be populated with secondary or action links and displayed inline with or above the main navigation.'),
     ];
@@ -236,7 +236,7 @@ class SiteConfiguration {
         'bold' => $this->t('Bold'),
         'normal' => $this->t('Normal'),
       ],
-      '#description'    => $this->t('Headers are bold by default, but can also be set to the same font weight as normal text.'),
+      '#description'    => $this->t('Headings are bold by default, but can also be set to the same font weight as normal text.'),
     ];
 
     $form['misc'] = [

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.6'
+version: '2.6.1'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
This update:
- Reorganizes the _Appearance and layout_ section of CU Boulder site settings into three categories: _Header and navigation_, _Page content_, and _Miscellaneous_.
- Adds a _Heading font_ setting. The setting defaults to _Bold_ but can also be set to _Normal_. CuBoulder/tiamat-theme#516.
- Swaps the location of _Inline_ and _Above_ when choosing the secondary menu position. CuBoulder/tiamat-theme#551

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/578)