### PR TITLE
CU Boulder Site Configuration v2.6.2

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -141,7 +141,7 @@ class SiteConfiguration {
 
     $form['header'] = [
       '#type' => 'details',
-      '#title' => 'Site header and navigation',
+      '#title' => 'Header and navigation',
       '#open' => TRUE,
     ];
 
@@ -216,10 +216,21 @@ class SiteConfiguration {
     ];
 
     $form['header']['ucb_secondary_menu_button_display'] = [
-      '#type'           => 'checkbox',
-      '#title'          => $this->t('Display links in the secondary menu as buttions'),
+      '#type'           => 'select',
+      '#title'          => $this->t('Secondary menu button display'),
       '#default_value'  => theme_get_setting('ucb_secondary_menu_button_display', $themeName),
-      '#description'    => $this->t('Check this box to display the links in the secondary menu of this site as buttons instead of links.'),
+      '#options'        => [
+        'none' => $this->t('None (text only)'),
+        'blue' => $this->t('Blue'),
+        'gold' => $this->t('Gold'),
+        'gray' => $this->t('Gray'),
+      ],
+      '#description'    => $this->t('The links in the secondary menu can display as blue, gold, or gray buttons if desired.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="ucb_secondary_menu_position"]' => ['value' => 'inline'],
+        ],
+      ],
     ];
 
     $form['content'] = [

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.6.1'
+version: '2.6.2'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
This update changes "Display links in the secondary menu as buttons" to "Secondary menu button display" with options for none, blue, gold, and gray. The setting only appears if "Position of the secondary menu" is set to "Above the main navigation". CuBoulder/tiamat-theme#551

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/583)