### PR TITLE
CU Boulder Site Configuration v2.6.4

### DIFF
--- a/src/Form/AppearanceForm.php
+++ b/src/Form/AppearanceForm.php
@@ -97,6 +97,16 @@ class AppearanceForm extends ConfigFormBase {
     $this->service->buildThemeSettingsForm($form, $form_state);
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $advanced = [];
+      $advanced['ucb_sidebar_position'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Sidebar position'),
+        '#default_value' => theme_get_setting('ucb_sidebar_position', $theme),
+        '#options' => [
+          'right' => $this->t('Right (default)'),
+          'left' => $this->t('Left'),
+        ],
+        '#description' => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
+      ];
       $advanced['custom_logo'] = [
         '#type' => 'container',
       ];

--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -256,17 +256,6 @@ class SiteConfiguration {
       '#open' => TRUE,
     ];
 
-    $form['misc']['ucb_sidebar_position'] = [
-      '#type'           => 'select',
-      '#title'          => $this->t('Where to show sidebar content on a page'),
-      '#default_value'  => theme_get_setting('ucb_sidebar_position', $themeName),
-      '#options'        => [
-        $this->t('Left'),
-        $this->t('Right'),
-      ],
-      '#description'    => $this->t('Select if sidebar content should appear on the left or right side of a page.'),
-    ];
-
     // Choose where social share buttons are positioned on each page.
     $form['misc']['ucb_social_share_position'] = [
       '#type'           => 'select',

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.6.3'
+version: '2.6.4'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
This update:
- Fixes an error in Drupal 10.2 caused by a dependency on a `ThemeSettingsForm` class marked as internal. This dependency has been removed. Resolves CuBoulder/ucb_site_configuration#43
- Moves "Sidebar position" under Advanced in Appearance and layout, with the setting now expecting a value of either `left` or `right`. Updates are needed in the theme and profile to make the setting work and will be tagged as sister PRs, but aren't required to merge this PR. CuBoulder/tiamat-theme#633.

@jnicholCU assigned as the reviewer to test the primary fix of this update.