### PR TITLE
Fixes third-party services set to "all content" appearing on content in the exclude field (v2.8.1)

### DIFF
--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.8'
+version: '2.8.1'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
Apparently Drupal's query API is so limiting that they actively encourage [duplicating the exact same code 3 times](https://www.drupal.org/docs/8/api/database-api/dynamic-queries/conditions#s-using-not-in-with-multi-value-field-like-roles-user-entity) in the documentation, big yikes. Instead of a query condition this update just grabs all of them and uses PHP to filter some out.

Resolves CuBoulder/ucb_site_configuration#51