### PR TITLE
Fixes People List Filter labels

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -380,8 +380,8 @@ class SiteConfiguration {
     $variables['people_list_department_label'] = $settings->get('people_list_department_label') ?? 'Department';
     $variables['people_list_job_type_label'] = $settings->get('people_list_job_type_label') ?? 'Job Type';
     $variables['people_list_filter_1_label'] = $settings->get('people_list_filter_1_label') ?? 'Filter 1';
-    $variables['people_list_filter_2_label'] = $settings->get('people_list_filter_1_label') ?? 'Filter 2';
-    $variables['people_list_filter_3_label'] = $settings->get('people_list_filter_1_label') ?? 'Filter 3';
+    $variables['people_list_filter_2_label'] = $settings->get('people_list_filter_2_label') ?? 'Filter 2';
+    $variables['people_list_filter_3_label'] = $settings->get('people_list_filter_3_label') ?? 'Filter 3';
   }
 
   /**


### PR DESCRIPTION
Previously there was an error in the site configuration where the set Filter 1 label would be presented for Filter 2 and Filter 3. This has been corrected and allows the People List Page to access the correct term labels.

Resolves #60 