### PR TITLE
Increases the maximum length of the "Content" field on third-party services entities (v2.9.1)

### DIFF
--- a/src/Form/ExternalServiceIncludeEntityForm.php
+++ b/src/Form/ExternalServiceIncludeEntityForm.php
@@ -117,6 +117,7 @@ class ExternalServiceIncludeEntityForm extends EntityForm {
         '#target_type' => 'node',
         '#title' => $this->t('Content'),
         '#description' => $this->t('Specify content to include or exclude (optional). Multiple entries may be seperated by commas.'),
+        '#maxlength' => 10000,
         '#default_value' => $entity->getNodes(),
         '#tags' => TRUE,
       ],

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.9'
+version: '2.9.1'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
Previously, a site wasn't able to include or exclude all the pages they wanted to due to a default character limit on the "Content" field on third-party services entities. This update increases the character limit to 10,000.

Resolves CuBoulder/ucb_site_configuration#72