### PR TITLE
Adds Sidebar color options

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -202,6 +202,17 @@ class SiteConfiguration {
       '#description'    => $this->t('Select a style for the main navigation menu.'),
     ];
 
+    $form['header']['ucb_sidebar_menu_style'] = [
+      '#type'           => 'select',
+      '#title'          => $this->t('Sidebar menu style'),
+      '#default_value'  => theme_get_setting('ucb_sidebar_menu_style', $themeName) ?? 'gold',
+      '#options'        => [
+        'gold'   => $this->t('Gold'),
+        'light-gray' => $this->t('Light Gray'),
+      ],
+      '#description'    => $this->t('Select a style for the sidebar navigation menu.'),
+    ];
+
     $form['header']['ucb_breadcrumb_nav'] = [
       '#type'           => 'checkbox',
       '#title'          => $this->t('Show breadcrumb navigation on pages'),


### PR DESCRIPTION
Options for sidebar menu styles added. Default is the current D10 Gold, and the light gray option mimics the D7 style

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1544