### PR TITLE
Updates site affiliation (v2.10)

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -146,8 +146,8 @@ site_affiliation_options:
     label: 'Office of Institutional Equity'
     type_restricted: false
   integrity_safety_compliance:
-    url: ''
-    label: 'Office of Integrity, Safety and Compliance'
+    url: 'https://www.colorado.edu/compliance'
+    label: 'Office of Compliance, Ethics and Policy'
     type_restricted: false
   strategic_relations_comm:
     url: 'https://www.colorado.edu/strategicrelations'

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.9.1'
+version: '2.10'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -133,11 +133,27 @@ function ucb_site_configuration_update_9507() {
 }
 
 /**
+ * Updates a site affiliation.
+ *
  * Renames Infrastructure and Sustainability to Infrastructure and Resilience.
  *
  * Introduced in version 2.9 to address issue #65.
  */
 function ucb_site_configuration_update_9508() {
+  _ucb_site_configuration_update_config([
+    'site_affiliation_options',
+  ]);
+}
+
+/**
+ * Updates a site affiliation.
+ *
+ * Renames Office of Integrity, Safety and Compliance to Office of Compliance,
+ * Ethics and Policy, and adds a URL to this affiliation.
+ *
+ * Introduced in version 2.10 to address issue #74.
+ */
+function ucb_site_configuration_update_9509() {
   _ucb_site_configuration_update_config([
     'site_affiliation_options',
   ]);


### PR DESCRIPTION
This update renames _Office of Integrity, Safety and Compliance_ to _Office of Compliance, Ethics and Policy_, and adds a URL to this affiliation.

[change] Resolves CuBoulder/ucb_site_configuration#74