### PR TITLE
Removes unused include templates and settings (v2.11)

### DIFF
--- a/src/SiteConfiguration.php
+++ b/src/SiteConfiguration.php
@@ -363,18 +363,6 @@ class SiteConfiguration {
         '#default_value'  => theme_get_setting('ucb_homepage_header', $themeName),
         '#description'    => $this->t('Check this box if you would like to hide the header. This is meant for the CU Homepage layout only.'),
       ];
-      $form['advanced']['ucb_secondary_menu_default_links'] = [
-        '#type'           => 'checkbox',
-        '#title'          => $this->t('Display the standard Boulder secondary menu in the header navigation region.'),
-        '#default_value'  => theme_get_setting('ucb_secondary_menu_default_links', $themeName),
-        '#description'    => $this->t('Check this box if you would like to display the default Boulder secondary menu links in the header.'),
-      ];
-      $form['advanced']['ucb_footer_menu_default_links'] = [
-        '#type'           => 'checkbox',
-        '#title'          => $this->t('Display the standard Boulder menus in the footer region.'),
-        '#default_value'  => theme_get_setting('ucb_footer_menu_default_links', $themeName),
-        '#description'    => $this->t('Check this box if you would like to display the default Boulder footer menu links in the footer.'),
-      ];
     }
   }
 

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^9 || ^10
 type: module
-version: '2.10'
+version: '2.11'
 package: CU Boulder
 dependencies:
   - block


### PR DESCRIPTION
This update removes the unused includes and settings originally intended for the CU Boulder homepage secondary and footer menus. They have instead built these out using the appropriate mechanisms available in Web Express and don't need custom code to support it.

CuBoulder/tiamat-theme#1537

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1554)