### PR TITLE
Remove debug logging from Goodkind bot

### DIFF
--- a/js/service-goodkind.js
+++ b/js/service-goodkind.js
@@ -1,8 +1,6 @@
 (function (drupalSettings) {
   const settings = drupalSettings.service_goodkind[0];
   if (!settings) return;
-
-  console.log(settings)
   // Set config BEFORE loading the script
   window.gkCBWConfig = {
     aiBotId: settings.ai_bot_id,


### PR DESCRIPTION
Needed to push the Goodkind chat bot to sandboxes for testing as it only works on a specified public domain. Included debug logging in case of issues, but this is no longer needed.

Resolves #82 