### PR TITLE
Renames Division of Student Affairs to Division of Student Life (v2.11)

### DIFF
--- a/config/install/ucb_site_configuration.configuration.yml
+++ b/config/install/ucb_site_configuration.configuration.yml
@@ -114,8 +114,8 @@ site_affiliation_options:
     label: 'Office of Strategic Initiatives'
     type_restricted: false
   student_affairs:
-    url: 'https://www.colorado.edu/studentaffairs'
-    label: 'Division of Student Affairs'
+    url: 'https://www.colorado.edu/studentlife'
+    label: 'Division of Student Life'
     type_restricted: false
   undergraduate_education:
     url: ''

--- a/ucb_site_configuration.info.yml
+++ b/ucb_site_configuration.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Site Configuration
 description: 'Allows CU Boulder site administrators to configure site-specific settings.'
 core_version_requirement: ^10 || ^11
 type: module
-version: '2.11'
+version: '2.12'
 package: CU Boulder
 dependencies:
   - block

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -194,7 +194,20 @@ function ucb_site_configuration_update_9510() {
 }
 
 /**
- * Updates the Third-party services to add the Goodkind AI chatbot option. 
+ * Updates a site affiliation.
+ *
+ * Renames Division of Student Affairs to Division of Student Life,
+ * and adds a URL to this affiliation.
+ *
+ * Introduced in version 2.11 to address issue #1629.
+ */
+function ucb_site_configuration_update_9511() {
+  _ucb_site_configuration_update_config([
+    'site_affiliation_options',
+  ]);
+
+/**
+ * Updates the Third-party services to add the Goodkind AI chatbot option.
  */
 
 function ucb_site_configuration_update_9511() {

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -205,7 +205,7 @@ function ucb_site_configuration_update_9511() {
   _ucb_site_configuration_update_config([
     'site_affiliation_options',
   ]);
-
+}
 /**
  * Updates the Third-party services to add the Goodkind AI chatbot option.
  */

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -194,6 +194,16 @@ function ucb_site_configuration_update_9510() {
 }
 
 /**
+ * Updates the Third-party services to add the Goodkind AI chatbot option.
+ */
+
+function ucb_site_configuration_update_9511() {
+  _ucb_site_configuration_update_config([
+    'external_services',
+  ]);
+}
+
+/**
  * Updates a site affiliation.
  *
  * Renames Division of Student Affairs to Division of Student Life,
@@ -201,17 +211,8 @@ function ucb_site_configuration_update_9510() {
  *
  * Introduced in version 2.11 to address issue #1629.
  */
-function ucb_site_configuration_update_9511() {
+function ucb_site_configuration_update_9512() {
   _ucb_site_configuration_update_config([
     'site_affiliation_options',
-  ]);
-}
-/**
- * Updates the Third-party services to add the Goodkind AI chatbot option.
- */
-
-function ucb_site_configuration_update_9511() {
-  _ucb_site_configuration_update_config([
-    'external_services',
   ]);
 }


### PR DESCRIPTION
This update renames 'Division of Student Affairs' to 'Division of Student Life', via an update hook. 

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1629