### PR TITLE
Short site name title tag

### DIFF
--- a/config/install/ucb_site_configuration.settings.yml
+++ b/config/install/ucb_site_configuration.settings.yml
@@ -1,6 +1,7 @@
 # Editable site settings (non-theme) will go here
 
 # Settings in "General"
+site_name_title_tag: ''
 site_type: ''
 site_affiliation: ''
 site_affiliation_label: ''

--- a/src/Form/GeneralForm.php
+++ b/src/Form/GeneralForm.php
@@ -129,6 +129,13 @@ class GeneralForm extends ConfigFormBase {
       '#default_value' => $systemSiteSettings->get('name'),
       '#required' => TRUE,
     ];
+    $form['site_name_title_tag'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Short name for title tag'),
+      '#default_value' => $settings->get('site_name_title_tag'),
+      '#description' => $this->t('An alternate, preferably shorter version of the site name used in HTML title tags. Leave blank to use the full site name above.'),
+      '#required' => FALSE,
+    ];
     $form['site_frontpage'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Home page'),
@@ -339,6 +346,9 @@ class GeneralForm extends ConfigFormBase {
       ->set('name', $form_state->getValue('site_name'))
       ->set('page.front', $form_state->getValue('site_frontpage'))
       ->set('page.404', $form_state->getValue('site_404'))
+      ->save();
+    $this->config('ucb_site_configuration.settings')
+      ->set('site_name_title_tag', $form_state->getValue('site_name_title_tag'))
       ->save();
     if ($this->user->hasPermission('edit ucb site advanced')) {
       $siteTypeId = $form_state->getValue('site_type');

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -250,3 +250,15 @@ function ucb_site_configuration_update_9515() {
     'site_affiliation_options',
   ]);
 }
+
+/**
+ * Adds the site name for title tag setting.
+ *
+ * Allows sites to specify a shorter alternate site name for use in HTML
+ * title tags to prevent excessively long titles.
+ */
+function ucb_site_configuration_update_9516() {
+  _ucb_site_configuration_update_settings([
+    'site_name_title_tag',
+  ]);
+}

--- a/ucb_site_configuration.module
+++ b/ucb_site_configuration.module
@@ -9,6 +9,46 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
+ * Uses alternate site name when [site:name] token is used and override is set.
+ *
+ * Overrides the [site:name] token (used by Metatag and others) with the shorter
+ * "Site name for title tag" when configured. This keeps title tags from
+ * becoming excessively long on content pages that use Metatag.
+ *
+ * Implements hook_tokens_alter().
+ */
+function ucb_site_configuration_tokens_alter(array &$replacements, array $context, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+  if ($context['type'] !== 'site' || !isset($context['tokens']['name'])) {
+    return;
+  }
+
+  $titleTagName = \Drupal::config('ucb_site_configuration.settings')->get('site_name_title_tag');
+  if (empty(trim($titleTagName))) {
+    return;
+  }
+
+  $replacements[$context['tokens']['name']] = $titleTagName;
+  $bubbleable_metadata->addCacheTags(['config:ucb_site_configuration.settings']);
+}
+
+/**
+ * Replaces the site name in head_title for non-Metatag pages (e.g. admin).
+ *
+ * On pages where Metatag does not run, Drupal core sets head_title with
+ * separate 'title' and 'name' keys. This alters the 'name' value when the
+ * override is configured.
+ *
+ * Implements hook_preprocess_HOOK().
+ */
+function ucb_site_configuration_preprocess_html(array &$variables) {
+  $titleTagName = \Drupal::config('ucb_site_configuration.settings')->get('site_name_title_tag');
+  if (!empty(trim($titleTagName)) && isset($variables['head_title']['name'])) {
+    $variables['head_title']['name'] = $titleTagName;
+    $variables['#cache']['tags'][] = 'config:ucb_site_configuration.settings';
+  }
+}
+
+/**
  * Enables site general settings to be referenced from the page template.
  *
  * Implements hook_preprocess_HOOK().


### PR DESCRIPTION
Add a new `site_name_title_tag` option that allows site managers, devs, architects to change their site's name that shows in the title tag. Preferably a shorter, non-acronym, for SEO purposes.

Update hook available for existing sites to have the option added.

Resolves #101 