### PR TITLE
ToS Enable Update

### DIFF
--- a/config/install/ucb_site_configuration.settings.yml
+++ b/config/install/ucb_site_configuration.settings.yml
@@ -11,7 +11,7 @@ site_search_enabled:
 site_search_label: ''
 site_search_url: ''
 gtm_account: ''
-tos_acceptance_enabled: false
+tos_acceptance_enabled: true
 
 # Settings in "Content types"
 article_date_format: '0'

--- a/ucb_site_configuration.install
+++ b/ucb_site_configuration.install
@@ -262,3 +262,14 @@ function ucb_site_configuration_update_9516() {
     'site_name_title_tag',
   ]);
 }
+
+/**
+ * Enables Terms of Service acceptance on existing sites.
+ *
+ * Aligns active config with the default in install/ucb_site_configuration.settings.yml.
+ */
+function ucb_site_configuration_update_9517() {
+  _ucb_site_configuration_update_settings([
+    'tos_acceptance_enabled',
+  ]);
+}


### PR DESCRIPTION
Updated ToS option to be enabled by default so all sites will use it. Added update hook so that the existing sites that have this option disabled will now be enabled.

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1793